### PR TITLE
fix(build): Fix missing toNodes issue

### DIFF
--- a/src/util/graphql.js
+++ b/src/util/graphql.js
@@ -11,4 +11,4 @@ const toNodes = (data, mapNode = identity) =>
 
 const toNodesWithImage = data => toNodes(data, hoistChildImageSharp);
 
-export { toNodesWithImage };
+export { toNodes, toNodesWithImage };


### PR DESCRIPTION
- Add export for `toNodes` to GraphQL util

Closes #158.