### PR TITLE
(fix) 214 Contact Us Text Center IE

### DIFF
--- a/src/components/organisms/contact/ContactHeader.jsx
+++ b/src/components/organisms/contact/ContactHeader.jsx
@@ -73,8 +73,8 @@ const LocationText = styled.span`
 const LocationTagline = styled.p`
   font-style: italic;
   margin: 0 auto 2em;
-  width: 100%;
   max-width: 17em;
+  width: 100%;
 
   ${mediaQuery.small`
     font-size: 2em;

--- a/src/components/organisms/contact/ContactHeader.jsx
+++ b/src/components/organisms/contact/ContactHeader.jsx
@@ -73,6 +73,7 @@ const LocationText = styled.span`
 const LocationTagline = styled.p`
   font-style: italic;
   margin: 0 auto 2em;
+  width: 100%;
   max-width: 17em;
 
   ${mediaQuery.small`
@@ -86,6 +87,8 @@ const LocationTagline = styled.p`
 
 const ScrollButton = styled(CallToAction)`
   margin: 0 auto;
+  max-width: 400px;
+  width: 100%;
 `;
 
 const Scroll = styled.img`


### PR DESCRIPTION
Added widths to LocationTagline and ScollButton

Although dealing with widths, may be related to known IE flexbox bug:
https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview

Closes #214 and #215 