### PR TITLE
chore(browser-matrix): Remove browser list duplication

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,4 @@
 {
-  "presets": ["react", "es2015", "stage-1",
-    ["env", {
-      "targets": {
-        "browsers": ["ie >= 11", "edge >= 16", "last 2 Chrome versions", "safari >= 10.1", "firefox >= 52", "ChromeAndroid >= 62", "iOS >= 10"]
-      }
-    }]
-  ],
+  "presets": ["react", "es2015", "stage-1"],
   "plugins": ["add-module-exports"]
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -12,7 +12,6 @@
     "value-list-max-empty-lines": null,
     "declaration-empty-line-before": null,
     "plugin/no-unsupported-browser-features": [ true, {
-      "browsers": ["ie >= 11", "edge >= 16", "last 2 Chrome versions", "safari >= 10.1", "firefox >= 52", "ChromeAndroid >= 62", "iOS >= 10"],
       "severity": "warning"
     }]
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,15 @@
     "stylelint-processor-styled-components": "^1.2.1",
     "svg-react-loader": "^0.4.5"
   },
+  "browserslist": [
+    "ie >= 11",
+    "edge >= 16",
+    "last 2 Chrome versions",
+    "safari >= 10.1",
+    "firefox >= 52",
+    "ChromeAndroid >= 62",
+    "iOS >= 10"
+  ],
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",


### PR DESCRIPTION
Removed browser arrays from .babelrc and .stylelintrc, added it to package.json

I think I did this right? `npx browserslist` works as before, but I'm not sure how to check if Babel is getting the list automatically. Help is appreciated.

Closes #207 