### PR TITLE
#264 fix mobile nav no scroll

### DIFF
--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -217,8 +217,9 @@ class GlobalNavigation extends React.Component {
   componentDidUpdate() {
     if (this.state.isOpen) {
       document.body.classList.add('noScroll');
+    } else {
+      document.body.classList.remove('noScroll');
     }
-    document.body.classList.remove('noScroll');
   }
 
   handleClick = () => {

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -16,7 +16,8 @@ injectGlobal`
     padding: 0;
   }
 
-  .noScroll {
+  .noScroll > div {
+    height: 100vh;
     overflow: hidden;
   }
 `;


### PR DESCRIPTION
Closes #264 for good, hopefully.

Overflow: hidden wasn't working because a height needed to be designated. It is now.