### PR TITLE
fix(blog) Blog Link Fails IE11

### DIFF
--- a/src/html.jsx
+++ b/src/html.jsx
@@ -96,6 +96,8 @@ class Html extends React.Component {
           <title>Base Two</title>
           {headComponents}
           {css}
+
+          <script src="https://cdn.polyfill.io/v2/polyfill.min.js" />
         </head>
         <body {...bodyAttributes}>
           {preBodyComponents}


### PR DESCRIPTION
Errors pointed to Luxon - used fix found here: https://moment.github.io/luxon/docs/manual/install.html