### PR TITLE
fix(site): Space After Navigation Link Clicked in IE

### DIFF
--- a/src/components/organisms/ContactUs.jsx
+++ b/src/components/organisms/ContactUs.jsx
@@ -9,6 +9,7 @@ const Wrapper = styled(Section)`
   display: block;
   padding-bottom: 45vw;
   position: relative;
+  overflow-x: hidden;
 
   ${mediaQuery.large`
     padding-bottom: 28em;

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -23,7 +23,7 @@ injectGlobal`
 
     ${mediaQuery.small`
       height: auto;
-      overflow: scroll;
+      overflow: auto;
     `};
   }
 `;


### PR DESCRIPTION
Updated overflow on page and on Contact Us wrapper to fix IE bug.

Closes #273 