### PR TITLE
fix(blog): Blog mobile no scroll

### DIFF
--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -276,7 +276,9 @@ class GlobalNavigation extends React.Component {
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/blog">Blog</NavLink>
+              <NavLink to="/blog" onClick={this.handleLinkClick}>
+                Blog
+              </NavLink>
             </NavItem>
             <NavItem>
               <NavLink to="/#contact-us" onClick={this.handleLinkClick}>


### PR DESCRIPTION
I think this'll fix it: the blog link in the Global Nav now has a click handler.

Closes #298 