### PR TITLE
fix(blog): Blog background color

### DIFF
--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -31,9 +31,7 @@ injectGlobal`
 const POST_REGEX = /\d{4}\/\d{2}\/\d{2}/;
 
 const isBlogPage = location =>
-  location.pathname === '/blog' ||
-  '/blog/' ||
-  location.pathname.match(POST_REGEX);
+  location.pathname.indexOf('blog') > -1 || location.pathname.match(POST_REGEX);
 
 class Template extends React.Component {
   static defaultPropes = {};

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -31,7 +31,9 @@ injectGlobal`
 const POST_REGEX = /\d{4}\/\d{2}\/\d{2}/;
 
 const isBlogPage = location =>
-  location.pathname === '/blog' || location.pathname.match(POST_REGEX);
+  location.pathname === '/blog' ||
+  '/blog/' ||
+  location.pathname.match(POST_REGEX);
 
 class Template extends React.Component {
   static defaultPropes = {};


### PR DESCRIPTION
Added one more location string to the script that determines whether a page is a blog page. I suspect (and have seen on my own phone) that mobile Chrome adds a trailing slash on refresh.

Closes #297