### PR TITLE
fix(hero): Hero background gets cut off on mobile.

### DIFF
--- a/src/components/organisms/Hero.jsx
+++ b/src/components/organisms/Hero.jsx
@@ -17,9 +17,8 @@ const HeroHeader = styled.header`
   background-repeat: no-repeat;
   background-size: 100%;
   background-color: ${themed('color.background')};
-  height: 100vh;
+  height: 110vh;
   padding: 3em 0 0 0;
-  position: relative;
   text-align: center;
 
   ${mediaQuery.small`
@@ -80,17 +79,17 @@ const HeroTagline = styled(P)`
 `;
 
 const SatelliteIndicator = styled.img`
-  margin-top: 0.5em;
   width: 3em;
 
   ${mediaQuery.xsmall`
-    position: absolute;
     left: calc(50% - 21px);
-    bottom: 15px;
+    position: absolute;
+    top: calc(100vh - 100px);
     width: 42px;
   `};
 
   ${mediaQuery.small`
+    margin-top: 0.5em;
     position: relative;
     width: 4em;
   `};

--- a/src/components/organisms/Hero.jsx
+++ b/src/components/organisms/Hero.jsx
@@ -17,7 +17,7 @@ const HeroHeader = styled.header`
   background-repeat: no-repeat;
   background-size: 100%;
   background-color: ${themed('color.background')};
-  height: 110vh;
+  height: 120vh;
   padding: 3em 0 0 0;
   text-align: center;
 


### PR DESCRIPTION
Issue: The hero background has an aspect ratio such that it can't fully fit on smaller devices (when the width is set to 100vw). 

Fix: By increasing the height of the container to 110vh, the background will not be cut off anymore. 

Fallout: The Scroll Link got its position from the height of the Hero container, so that was forcing it off-screen also. I set the Scroll Link to be positioned based on the view height instead of the Hero height, which seems to fix it.

Closes #259 