### PR TITLE
fix(blog): Broken Blog Images and Links

### DIFF
--- a/_content/posts/2013-08-23-startup-magnet-poetry.md
+++ b/_content/posts/2013-08-23-startup-magnet-poetry.md
@@ -15,7 +15,7 @@ StumbleUpon + LinkedIn. Google Glass meets Nike+ meets Yelp, etc.
 I spent a couple hours this afternoon and got a working proof of concept! It was
 such a rewarding thing to go from concept to finished product so quickly!
 
-![magnetic startup poetry](http://i.imgur.com/rLPiq0K.jpg)
+![magnetic startup poetry](https://i.imgur.com/rLPiq0K.jpg)
 
 ### Desperately Seeking Contributions
 

--- a/_content/posts/2015-05-13-regex-replace-with-groups.md
+++ b/_content/posts/2015-05-13-regex-replace-with-groups.md
@@ -38,7 +38,7 @@ and understand") pattern matching grammar. It provides for more advanced
 searching capabilities than a standard text-base search. Luckily Visual Studio
 provides for searching via Regex (screenshot is of Visual Studio 2013).
 
-![Visual Studio regex search option](http://i.imgur.com/MAzCFjd.jpg)
+![Visual Studio regex search option](https://i.imgur.com/MAzCFjd.jpg)
 
 With **Use Regular Expressions** selected in Visual Studio we can take advantage
 of regex, including its group capturing via parentheses.
@@ -49,8 +49,7 @@ In the **Find what** we can place the following regex query
 template: require\('Project/(.*)'\)
 ```
 
-This tells Visual Studio to match everything that directly matches `template:
-require(Project/`&lt;any number of characters&gt;`)'`. Note that the require's
+This tells Visual Studio to match everything that directly matches `template: require(Project/`&lt;any number of characters&gt;`)'`. Note that the require's
 parentheses needed to be escaped with `\` because the parentheses are part of
 the regex syntax. You can use the
 [http://www.regexr.com/](http://www.regexr.com/) online tool to test the regex

--- a/_content/posts/2015-06-01-shortcut-month.md
+++ b/_content/posts/2015-06-01-shortcut-month.md
@@ -89,7 +89,7 @@ This simple key combination allows you to search the menu options. So, if you
 want to change the font to "Courier New" you can hit <kbd>alt</kbd> +
 <kbd>/</kbd>, type "cour", and hit enter.
 
-![Google Docs search menu](http://i.imgur.com/myyRI6w.png)
+![Google Docs search menu](https://i.imgur.com/myyRI6w.png)
 
 Generally the individual shortcut for each feature is still faster, but a
 shortcut that you can remember is better than one you cannot. Plus, when you use
@@ -127,7 +127,7 @@ In IDEs, such as Web Storm and Visual Studio, <kbd>ctrl</kbd> +
 Web Storm <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>v</kbd> will provide a
 window to select which of the previously copied texts to paste.
 
-![WebStorm paste special](http://i.imgur.com/9a65jrl.png)
+![WebStorm paste special](https://i.imgur.com/9a65jrl.png)
 
 Visual Studio will progressively paste the next most recently copied item with
 each <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>v</kbd> click (while holding
@@ -215,7 +215,7 @@ for even a portion of the day then it's worthwhile learning some common
 shortcuts. Today we'll go over how to select columns and rows without using the
 mouse.
 
-![Select column](http://i.imgur.com/x3gocRv.png)
+![Select column](https://i.imgur.com/x3gocRv.png)
 
 | Key combination                     | Result                                              |
 | ----------------------------------- | --------------------------------------------------- |
@@ -281,7 +281,7 @@ All too often users shift their mouse to the top of the screen simply to place
 their cursor in the browser address bar. Cut that bad habit with this simple
 shortcut.
 
-![Browser address bar](http://i.imgur.com/wC5hjP9.png)
+![Browser address bar](https://i.imgur.com/wC5hjP9.png)
 
 | Key combination               | Result                                                          |
 | ----------------------------- | --------------------------------------------------------------- |
@@ -328,7 +328,7 @@ it's to get back to your search results or to return to an embarrassingly
 picture</a> that you stumbled upon. You're in luck - there's a shortcut for
 that.
 
-![Browser navigation](http://i.imgur.com/VMZT1KD.png)
+![Browser navigation](https://i.imgur.com/VMZT1KD.png)
 
 | Key combination                         | Result                                            |
 | --------------------------------------- | ------------------------------------------------- |
@@ -401,7 +401,7 @@ If you like starting at "My Computer" (labeled as just "Computer" in Windows 7)
 then <kbd>win</kbd> + <kbd>e</kbd> is your new best friend. It opens the
 Computer directory up immediately so that you can begin to navigate the folders.
 
-![My computer](http://i.imgur.com/johmmCX.png)
+![My computer](https://i.imgur.com/johmmCX.png)
 
 Folders can be navigated quickly by arrowing down/up to the folder you wish to
 open and then clicking <kbd>enter</kbd>. If you're staring at a long list of
@@ -455,7 +455,7 @@ instance, <kbd>ctrl</kbd> + <kbd>n</kbd> will create a new document in Word and
 a new tab in <a href="http://www.sublimetext.com/" target="_blank">Sublime
 Text</a>.
 
-![Chrome incognito](http://i.imgur.com/AI7u4Ek.png)
+![Chrome incognito](https://i.imgur.com/AI7u4Ek.png)
 
 If you're feeling a little sneakier you open a new Icognito window in Chrome via
 <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>n</kbd>. Icognito mode allows your to
@@ -471,7 +471,7 @@ application's search functionality can be a savior, but ironically the search
 functionality can be difficult to find. Stop searching for the search so that
 you can begin searching with these shortcuts.
 
-![My computer](http://i.imgur.com/gTzjt7w.png)
+![My computer](https://i.imgur.com/gTzjt7w.png)
 
 | Key combination                  | Result                                               |
 | -------------------------------- | ---------------------------------------------------- |
@@ -649,7 +649,7 @@ that post. It's like telling Facebook
 is my final answer</a>". This shortcut also works in Gmail to send an email that
 you are composing.
 
-![Facebook post](http://i.imgur.com/YG4uNGU.png)
+![Facebook post](https://i.imgur.com/YG4uNGU.png)
 
 On the flipside, if you're in a field that uses the <kbd>enter</kbd> key to
 submit the entry (such as Excel cells), you can generally use <kbd>alt</kbd> +
@@ -663,7 +663,7 @@ Have you ever wondered if there is a shortcut that immediately places your
 cursor in a website's search box? Probably not, but after learning this shortcut
 you'll never risk wondering.
 
-![Twitter search](http://i.imgur.com/xUhbXtO.png)
+![Twitter search](https://i.imgur.com/xUhbXtO.png)
 
 | Key combination | Result                                                               |
 | --------------- | -------------------------------------------------------------------- |
@@ -691,7 +691,7 @@ shortcuts to be a top lister.
 | <kbd>ctrl</kbd> + <kbd>[</kbd>                    | Unindent line or selection  |
 | <kbd>shift</kbd> + <kbd>enter</kbd>               | Add new line without bullet |
 
-![Gmail bulleting](http://i.imgur.com/c4KgJfU.png)
+![Gmail bulleting](https://i.imgur.com/c4KgJfU.png)
 
 <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>7</kbd> will get you started with a
 numeric list. If bullets are more your thing than swap the <kbd>7</kbd> for an
@@ -734,7 +734,7 @@ baby. It provides multiple channels (like chat rooms) to have conversations, but
 having to click on the channel you want to view is silly when there is a
 shortcut for that.
 
-![Slack logo](http://i.imgur.com/7PpM4MT.jpg =300x)
+![Slack logo](https://i.imgur.com/7PpM4MT.jpg =300x)
 
 | Key combination                | Result                                  |
 | ------------------------------ | --------------------------------------- |

--- a/_content/posts/2015-12-30-jscs-intellij-setup.md
+++ b/_content/posts/2015-12-30-jscs-intellij-setup.md
@@ -67,7 +67,7 @@ location you can do so by selecting the second option. The Code style preset can
 be set from this window, but we've basically already done that by creating our
 .jscsrc file and setting the preset as airbnb there.
 
-![JSCS Settings](http://i.imgur.com/k4t5I9M.png)
+![JSCS Settings](https://i.imgur.com/k4t5I9M.png)
 
 This should start working once you hit ok and you'll see any format/style issues
 with your projects javascript files. You can manually clean them up, but I
@@ -77,26 +77,26 @@ config into WebStorm's code style settings. Lets set that up now.
 Open **Settings** and go to **Editor > Code Style > Javascript**. Then select
 the **Manage...** button.
 
-![Javascript Code Style Settings](http://i.imgur.com/paw2sxV.png)
+![Javascript Code Style Settings](https://i.imgur.com/paw2sxV.png)
 
 This will open another window, select **Import**.
 
-![Code Style Schemes](http://i.imgur.com/ttmSNi7.png)
+![Code Style Schemes](https://i.imgur.com/ttmSNi7.png)
 
 This opens yet another window, select **JSCS config file** and click **OK**
 
-![Scheme Import From](http://i.imgur.com/GVM7N2m.png)
+![Scheme Import From](https://i.imgur.com/GVM7N2m.png)
 
 This will open a **Select Path** dialog window. Just find your project's root
 directory and select the .jscsrc file located in the root. Then click **OK**.
 
-![Select Path](http://i.imgur.com/LmacVz7.png)
+![Select Path](https://i.imgur.com/LmacVz7.png)
 
 You can select to update the scheme you had selected, or create a new scheme.
 We'll create a new scheme called JSCS. Optionally you could also select a Code
 Style Preset from this window as well. Last click **OK**.
 
-![Import from JSCS config](http://i.imgur.com/gFJWKTW.png)
+![Import from JSCS config](https://i.imgur.com/gFJWKTW.png)
 
 Now you can close the **Code Style Schemes** dialog. Your javascript code style
 settings will be as close as possible to your settings in the .jscs config file.
@@ -118,7 +118,7 @@ jscs myfilename.js --fix
 Or WebStorm has an option to fix JSCS issues in line via context menu on the
 problem area. Here's a visual example of what that looks like:
 
-![Fix JSCS context menu](http://i.imgur.com/cOABQHg.png)
+![Fix JSCS context menu](https://i.imgur.com/cOABQHg.png)
 
 This is a little tricky to get this to popup, but if you click on the red
 squiggly and look for the red light bulb, you have an option to "Fix the current
@@ -135,7 +135,7 @@ Problems and push the edit (green pencil) button. I set mine to <kbd>opt</kbd> +
 <kbd>cmd</kbd> + <kbd>S</kbd> which was unused, but feel free to set it to
 something else that makes sense to you and/or your team.
 
-![Keymap JSCS Fix shortcut](http://i.imgur.com/DvfLmsi.png)
+![Keymap JSCS Fix shortcut](https://i.imgur.com/DvfLmsi.png)
 
 Now whenever you see JSCS errors just use the shortcut key and it'll clean those
 babies right up!

--- a/_content/posts/2016-05-25-a-google-io-experience.md
+++ b/_content/posts/2016-05-25-a-google-io-experience.md
@@ -11,7 +11,7 @@ can say that I’ve been to Nerd Woodstock. Last week was the 10th annual
 place at the Shoreline Amphitheatre, near Google’s main campus in Mountain View,
 California.
 
-![Google I/O 2016 sculpture](http://i.imgur.com/DWAVnDC.jpg "Google I/O 2016 sculpture")
+![Google I/O 2016 sculpture](https://i.imgur.com/DWAVnDC.jpg "Google I/O 2016 sculpture")
 
 The Keynote began with an amazing live
 [Earth Harp](http://williamandtheearthharp.com "Earth Harp") performance of a
@@ -69,8 +69,7 @@ threw the “1 billion mobile users” statistic around a lot. They also harped
 heavily on their concept of Progressive Web Apps, which are essentially adaptive
 websites with some Android flair thrown in (such as the ability to pin to the
 home screen, offline capabilities, and access to the notifications API) and
-their open source project called
-[AMP](https://www.ampproject.org/ "AMP open source project") (Accelerated Mobile
+their open source project called[AMP](https://www.ampproject.org/ "AMP open source project") (Accelerated Mobile
 Pages).
 
 ## The Conference
@@ -79,26 +78,25 @@ I was a little concerned, upon first receiving my ticket information, about the
 fact that the bulk of the conference appeared to be taking place in a series of
 parking lots.
 
-![The map I/O provided to attendees showing large parking lots full of buses and lacking shade.](http://i.imgur.com/vNDImS6.png "The map I/O provided to attendees showing large parking lots full of buses and lacking shade.")
+![The map I/O provided to attendees showing large parking lots full of buses and lacking shade.](https://i.imgur.com/vNDImS6.png "The map I/O provided to attendees showing large parking lots full of buses and lacking shade.")
 
 Once I arrived I was reassured to find that all the presentations (save the ones
 in the Amphitheatre) would be given in enormous tents with top-of-the-line AV
 equipment. They weren’t all domes, and some were much larger, which was good
 considering the amount of people wanting to get in.
 
-![large geodesic dome tent](http://cdn.arstechnica.net/wp-content/uploads/2016/05/IMG_6889.jpg "Large geodesic dome tent, image credit: Andrew Cunningham, Ars Technica")
+![large geodesic dome tent](https://cdn.arstechnica.net/wp-content/uploads/2016/05/IMG_6889.jpg "Large geodesic dome tent, image credit: Andrew Cunningham, Ars Technica")
 Image credit: [Andrew Cunningham, Ars
-Technica](http://arstechnica.com/gadgets/2016/05/google-io-2016-is-part-developer-conference-and-part-county-fair/
-“Image credit:Andrew Cunningham, Ars Technica”)
+Technica](https://arstechnica.com/gadgets/2016/05/google-io-2016-is-part-developer-conference-and-part-county-fair/)
 
-![Monica Dinculescu presents on Web Components at Google I/O 2016](http://i.imgur.com/Pm2E2e0.jpg "Monica Dinculescu presents on Web Components at Google I/O 2016")
+![Monica Dinculescu presents on Web Components at Google I/O 2016](https://i.imgur.com/Pm2E2e0.jpg "Monica Dinculescu presents on Web Components at Google I/O 2016")
 [Monica Dinculescu](http://meowni.ca/) gives her presentation on Web Components
 inside a dome tent.
 
 ### The Lines
 
 Yes,
-[there were long lines](http://thenextweb.com/google/2016/05/19/google-io-2016-look-not-run-large-event/ "Google I/O 2016: A look at how not to run a large event"),
+[there were long lines](https://thenextweb.com/google/2016/05/19/google-io-2016-look-not-run-large-event/ "Google I/O 2016: A look at how not to run a large event"),
 and yes, I did miss most of the sessions I’d hoped to see on Wednesday.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">The lines for sessions are insane, but I finally made it into one. Excited to hear <a href="https://twitter.com/kaihaley">@kaihaley</a> talk sprints! <a href="https://twitter.com/hashtag/io16?src=hash">#io16</a> <a href="https://t.co/LP5fBftJdd">pic.twitter.com/LP5fBftJdd</a></p>&mdash; Caitlin Steinert (@csteinert) <a href="https://twitter.com/csteinert/status/733054056294277121">May 18, 2016</a></blockquote>
@@ -111,7 +109,7 @@ were repeated on Friday.
 
 ### The Installations
 
-<img src="http://i.imgur.com/G3a1TAD.gif" style="float: right; margin: 0 0 2em 2em;" title="Interacting with a Nest using the Nest API and Polymer web components at Google I/O 2016" alt="Interacting with a Nest using the Nest API and Polymer web components at Google I/O 2016" />
+<img src="https://i.imgur.com/G3a1TAD.gif" style="float: right; margin: 0 0 2em 2em;" title="Interacting with a Nest using the Nest API and Polymer web components at Google I/O 2016" alt="Interacting with a Nest using the Nest API and Polymer web components at Google I/O 2016" />
 In the meantime, there was no shortage of interactive and cool stuff to keep attendees preoccupied. A portion of the Amphitheatre, which appeared to be a restaurant usually, was repurposed to house the [Google Code Labs](https://codelabs.developers.google.com/io2016 "Google Code Labs"), where developers were invited to sit down at workstations, some complete with Nests and other devices, to hack through hands-on exercises. Googlers roamed the area, answering questions. I, for one, am very proud of the web interface I cobbled together using Polymer and the Nest API.
 
 Further afield -- in the parking lots -- tent-shaded areas showed off products
@@ -121,10 +119,10 @@ sight-singing phones, and a plotter that drew out single-line portraits of
 attendees. A [Project Loon](https://www.google.com/loon "Project Loon") balloon
 was also on display.
 
-![Android Auto on display in a Maserati at Google I/O 2016](http://i.imgur.com/lPxEwWd.jpg "Android Auto on display in a Maserati at Google I/O 2016")
+![Android Auto on display in a Maserati at Google I/O 2016](https://i.imgur.com/lPxEwWd.jpg "Android Auto on display in a Maserati at Google I/O 2016")
 Android Auto on display in a Maserati. No big deal.
 
-![Project Loon balloon at Google I/O 2016](http://i.imgur.com/3AtWWOH.jpg "Project Loon balloon at Google I/O 2016")
+![Project Loon balloon at Google I/O 2016](https://i.imgur.com/3AtWWOH.jpg "Project Loon balloon at Google I/O 2016")
 [Project Loon](https://www.google.com/loon "Project Loon") brings the internet
 to all by way of stratosphere balloons.
 
@@ -220,7 +218,7 @@ night before the conference began. Aside from the delicious food and beautiful
 setup, it was exciting to be in the company of a couple hundred amazing tech
 industry women from all over the world.
 
-![Women Techmakers Dinner at Google I/O 2016](http://i.imgur.com/iNwyoRJ.jpg "The view from my seat at the Women Techmakers Dinner at Google I/O 2016")
+![Women Techmakers Dinner at Google I/O 2016](https://i.imgur.com/iNwyoRJ.jpg "The view from my seat at the Women Techmakers Dinner at Google I/O 2016")
 
 ![Women Techmakers Dinner, photo credit: Google Official Blog](https://4.bp.blogspot.com/-a6xxyTQJAqs/V0SblNa6F_I/AAAAAAAASVg/g7nZZk-AssIUiUswNBRWtIo1E5-9TInywCLcB/s1600/womentechmakers.png "Women Techmakers Dinner, photo credit: Google Official Blog")
 Photo credit: [Google Official Blog](https://googleblog.blogspot.com/)
@@ -231,7 +229,7 @@ it was exciting to be able to attend a happy hour hosted by the San Francisco
 chapter near the conference venue! In true Mountain View fashion, we commuted to
 the happy hour on Google’s brightly-painted fixie bikes.
 
-![The Girl Develop It biker gang makes their way to the GDI San Francisco happy hour at Google I/O 2016](http://i.imgur.com/vuDq6Zg.jpg "The Girl Develop It biker gang makes their way to the GDI San Francisco happy hour at Google I/O 2016")
+![The Girl Develop It biker gang makes their way to the GDI San Francisco happy hour at Google I/O 2016](https://i.imgur.com/vuDq6Zg.jpg "The Girl Develop It biker gang makes their way to the GDI San Francisco happy hour at Google I/O 2016")
 
 I’d also like to thank the rest of the Base Two team for letting me jet off to
 California a little over a week after joining the team (Hello, world!) with only

--- a/_content/posts/2017-01-03-apprenticeship-month-1.md
+++ b/_content/posts/2017-01-03-apprenticeship-month-1.md
@@ -45,7 +45,7 @@ what I would need to do, which helped us create issues in the backlog.
 project from the start, and I treated him as project lead. I checked in with
 him, talked over requirements, and we paired on some tasks together.
 
-![Project 1](http://i.imgur.com/AxDbeSq.png "Project 1 screenshot")
+![Project 1](https://i.imgur.com/AxDbeSq.png "Project 1 screenshot")
 
 We had a particularly good pairing session working on the sliders you can see in
 the photo. Screen sharing, I showed him how I was using Redux to handle the

--- a/_content/posts/2017-02-08-mac-setup.md
+++ b/_content/posts/2017-02-08-mac-setup.md
@@ -88,8 +88,8 @@ brew list             # Show all packages installed with Homebrew
 
 ##### Tips
 
-- Run `brew update` before using Homebrew as good practice.
-- After running `brew upgrade`, if a package isn't working, run `brew uninstall <package>` and then re-install it, `brew install <package>`
+* Run `brew update` before using Homebrew as good practice.
+* After running `brew upgrade`, if a package isn't working, run `brew uninstall <package>` and then re-install it, `brew install <package>`
 
 ##### Install
 
@@ -144,8 +144,8 @@ pip install ipython && pip3 install ipython
 
 I found that `ipython` was running Python3. Test your installations:
 
-- Run `ipython` to ensure it runs on Python2
-- Run `ipython3` to ensure it runs on Python3
+* Run `ipython` to ensure it runs on Python2
+* Run `ipython3` to ensure it runs on Python3
 
 If `ipython` runs on Python3:
 
@@ -199,12 +199,12 @@ apm ls
 Atom was installed when I got the Mac, so there might have been some setup I'm
 not aware of. These are the community packages I have installed:
 
-- highlight-selected
-- linter
-- linter-eslint
-- linter-stylelint
-- pretty-json
-- react
+* highlight-selected
+* linter
+* linter-eslint
+* linter-stylelint
+* pretty-json
+* react
 
 ##### Install
 

--- a/_content/posts/2017-02-08-mac-setup.md
+++ b/_content/posts/2017-02-08-mac-setup.md
@@ -88,9 +88,8 @@ brew list             # Show all packages installed with Homebrew
 
 ##### Tips
 
-* Run `brew update` before using Homebrew as good practice.
-* After running `brew upgrade`, if a package isn't working, run `brew uninstall
-  <package>` and then re-install it, `brew install <package>`
+- Run `brew update` before using Homebrew as good practice.
+- After running `brew upgrade`, if a package isn't working, run `brew uninstall <package>` and then re-install it, `brew install <package>`
 
 ##### Install
 
@@ -118,7 +117,7 @@ brew install python python3
 
 ### 5. iPython && iPython3
 
-![iPython](http://i.imgur.com/fYgg41c.gif)
+![iPython](https://i.imgur.com/fYgg41c.gif)
 
 If you aren't familiar with iPython I strongly recommend you try it out. As a
 Python REPL, it gives you a score of features over the plain interpreter.
@@ -145,8 +144,8 @@ pip install ipython && pip3 install ipython
 
 I found that `ipython` was running Python3. Test your installations:
 
-* Run `ipython` to ensure it runs on Python2
-* Run `ipython3` to ensure it runs on Python3
+- Run `ipython` to ensure it runs on Python2
+- Run `ipython3` to ensure it runs on Python3
 
 If `ipython` runs on Python3:
 
@@ -200,12 +199,12 @@ apm ls
 Atom was installed when I got the Mac, so there might have been some setup I'm
 not aware of. These are the community packages I have installed:
 
-* highlight-selected
-* linter
-* linter-eslint
-* linter-stylelint
-* pretty-json
-* react
+- highlight-selected
+- linter
+- linter-eslint
+- linter-stylelint
+- pretty-json
+- react
 
 ##### Install
 
@@ -215,7 +214,7 @@ not aware of. These are the community packages I have installed:
 
 ### 7. Itsycal
 
-![Itsycal](http://i.imgur.com/oTC5hlG.png)
+![Itsycal](https://i.imgur.com/oTC5hlG.png)
 
 This is a mini-calendar for the menu bar. I didn't realize how often I used
 Ubuntu's until it was gone.


### PR DESCRIPTION
Closes #354 

Note: The image issue is due to base2.io being https, and the imgur links being http.  I updated the links, it should work, but we won't know for sure until this is deployed.