### PR TITLE
Background Images Not Displaying in Mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "remark-react": "^4.0.1",
     "sharp": "^0.17.0",
     "styled-components": "^2.2.3",
+    "supports-webp": "^1.0.7",
     "typescript": "^2.6.2",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/util/style.js
+++ b/src/util/style.js
@@ -1,5 +1,6 @@
 import curry from 'lodash/curry';
 import get from 'lodash/get';
+import supportsWebP from 'supports-webp';
 import { lighten as _lighten } from 'polished';
 import { css } from 'styled-components';
 
@@ -41,14 +42,13 @@ const containerSizing = css`
   `};
 `;
 
-const webpBackground = (original, optimized) => css`
-  background-image: url(${original});
-  @media screen and (-webkit-min-device-pixel-ratio: 0) {
-    @supports (-webkit-appearance:none) {
-      background-image: url(${optimized});
-    }
-  }
-`;
+const webpBackground = (original, optimized) => {
+  const supportedImage = supportsWebP ? optimized : original;
+  const backgroundCss = css`
+    background-image: url(${supportedImage});
+  `;
+  return backgroundCss;
+};
 
 const themed = curry((path, props) => get(props.theme, path));
 


### PR DESCRIPTION
Closes #375 

The background images were not displaying on Apple devices because our method of support detection for webp was determining that Safari supported webp (it does not).

Used webp support detection package instead.