### PR TITLE
chore: linebreak-style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   },
   "parser": "babel-eslint",
   "rules": {
+    "linebreak-style": 0,
     "jsx-a11y/anchor-is-valid": [
       "error",
       {


### PR DESCRIPTION
Turn off the linebreak-style eslint rule because it causes issues for
Windows users. The recommended Git setting for windows users is to have
Git automatically change CRLF to LF on commit. Therefore the files are
CRLF when local, which eslint is complaining about.