### PR TITLE
feat(site): Smooth scrolling on nav link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16649,6 +16649,11 @@
         }
       }
     },
+    "smooth-scroll": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/smooth-scroll/-/smooth-scroll-16.1.2.tgz",
+      "integrity": "sha512-zo/61lPWCxzsjYfxbqr9a94PIFSU840+0e053+n6Hf0RcX8MtjtNXNSInEYRlbGaJ2/nezyEWPywsm3TCya0vQ=="
+    },
     "smoothscroll-polyfill": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8907,14 +8907,6 @@
         }
       }
     },
-    "gatsby-plugin-smoothscroll": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-smoothscroll/-/gatsby-plugin-smoothscroll-1.0.4.tgz",
-      "integrity": "sha512-B61Iv/rGj0X5Uo43EtY+CYnM1ER0Ld/GfDCr9O1v+BzJ15KT2LxWPyk5/CbKb4O4VuX4n+jcQrOVBEyg2D1jIA==",
-      "requires": {
-        "smoothscroll-polyfill": "^0.4.4"
-      }
-    },
     "gatsby-plugin-styled-components": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-3.0.7.tgz",
@@ -16653,11 +16645,6 @@
       "version": "16.1.2",
       "resolved": "https://registry.npmjs.org/smooth-scroll/-/smooth-scroll-16.1.2.tgz",
       "integrity": "sha512-zo/61lPWCxzsjYfxbqr9a94PIFSU840+0e053+n6Hf0RcX8MtjtNXNSInEYRlbGaJ2/nezyEWPywsm3TCya0vQ=="
-    },
-    "smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8907,6 +8907,14 @@
         }
       }
     },
+    "gatsby-plugin-smoothscroll": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-smoothscroll/-/gatsby-plugin-smoothscroll-1.0.4.tgz",
+      "integrity": "sha512-B61Iv/rGj0X5Uo43EtY+CYnM1ER0Ld/GfDCr9O1v+BzJ15KT2LxWPyk5/CbKb4O4VuX4n+jcQrOVBEyg2D1jIA==",
+      "requires": {
+        "smoothscroll-polyfill": "^0.4.4"
+      }
+    },
     "gatsby-plugin-styled-components": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-3.0.7.tgz",
@@ -16640,6 +16648,11 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         }
       }
+    },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-react-svg": "^2.1.1",
     "gatsby-plugin-sharp": "^2.2.11",
+    "gatsby-plugin-smoothscroll": "^1.0.4",
     "gatsby-plugin-styled-components": "^3.0.0",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-transformer-json": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-react-svg": "^2.1.1",
     "gatsby-plugin-sharp": "^2.2.11",
-    "gatsby-plugin-smoothscroll": "^1.0.4",
     "gatsby-plugin-styled-components": "^3.0.0",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-transformer-json": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "remark": "^9.0.0",
     "remark-react": "^4.0.3",
     "sharp": "^0.20.8",
+    "smooth-scroll": "^16.1.2",
     "styled-components": "^3.4.9",
     "supports-webp": "^1.0.7",
     "whatwg-fetch": "^3.0.0"

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -20,7 +20,9 @@ const mobileBottomMenu = {
   value: `${em('75px')}`,
 };
 
-
+if (typeof window !== `undefined`) {
+  SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
+};
 
 const MOBILE_NAVIGATION_BREAKPOINT = '767';
 
@@ -247,10 +249,6 @@ class GlobalNavigation extends React.Component {
     this.setState({ isOpen: false });
   };
 
-  componentDidMount() {
-    SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
-  }
-  
   render() {
     return (
       <NavBar

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { em } from 'polished';
 import windowSize from 'react-window-size';
+import SmoothScroll from 'smooth-scroll';
 import {
   A,
   BaseTwoLogo,
@@ -19,6 +20,8 @@ import { mediaQuery, themed } from '../../util/style';
 const mobileBottomMenu = {
   value: `${em('75px')}`,
 };
+
+SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
 
 const MOBILE_NAVIGATION_BREAKPOINT = '767';
 
@@ -257,7 +260,7 @@ class GlobalNavigation extends React.Component {
       >
         <MainNavigationContainer>
           <LogoToggleContainer>
-            <HomeLink href="/" title="Base Two - Home">
+            <HomeLink href="/#top" title="Base Two - Home">
               <BaseTwoLogo />
             </HomeLink>
             <MenuToggle aria-label="Toggle Menu" onClick={this.handleClick}>

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { em } from 'polished';
 import windowSize from 'react-window-size';
-import SmoothScroll from 'smooth-scroll/dist/smooth-scroll'
+import SmoothScroll from 'smooth-scroll/dist/smooth-scroll';
 import {
   A,
   BaseTwoLogo,
@@ -21,14 +21,13 @@ const mobileBottomMenu = {
 };
 
 if (typeof window !== `undefined`) {
-  SmoothScroll('a[href*="#"]', 
-  {
-    easing: 'easeOutQuad', 
+  SmoothScroll('a[href*="#"]', {
+    easing: 'easeOutQuad',
+    offset: '50',
     speed: 700,
     speedAsDuration: true,
-    offset: '50'
   });
-};
+}
 
 const MOBILE_NAVIGATION_BREAKPOINT = '767';
 
@@ -44,8 +43,8 @@ const NavBar = styled.nav`
 
   &.menu-open {
     height: 100vh;
-    transition: height 300ms ease-in;
     touch-action: none;
+    transition: height 300ms ease-in;
   }
 
   &.menu-closed {

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -1,4 +1,3 @@
-import scrollTo from 'gatsby-plugin-smoothscroll';
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -1,3 +1,4 @@
+import scrollTo from 'gatsby-plugin-smoothscroll';
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
@@ -265,7 +266,7 @@ class GlobalNavigation extends React.Component {
           </LogoToggleContainer>
           <NavList>
             <NavItem>
-              <NavLink to="/#services" onClick={this.handleLinkClick}>
+              <NavLink to="/#services" onClick={() => { this.handleLinkClick(); scrollTo('#services');}}>
                 Services
               </NavLink>
             </NavItem>

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -261,38 +261,38 @@ class GlobalNavigation extends React.Component {
             <HomeLink href="/#top" title="Base Two - Home">
               <BaseTwoLogo />
             </HomeLink>
-            <MenuToggle aria-label="Toggle Menu" onClickCapture={this.handleClick}>
+            <MenuToggle aria-label="Toggle Menu" onClick={this.handleClick}>
               <Icon name="menutoggle" />
             </MenuToggle>
           </LogoToggleContainer>
           <NavList>
             <NavItem>
-              <NavLink to="/#services" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/#services" onClick={this.handleLinkClick}>
                 Services
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#clients" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/#clients" onClick={this.handleLinkClick}>
                 Clients
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#team" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/#team" onClick={this.handleLinkClick}>
                 Team
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/jobs" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/jobs" onClick={this.handleLinkClick}>
                 Jobs
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/blog" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/blog" onClick={this.handleLinkClick}>
                 Blog
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#contact-us" onClickCapture={this.handleLinkClick}>
+              <NavLink to="/#contact-us" onClick={this.handleLinkClick}>
                 Contact
               </NavLink>
             </NavItem>

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -41,7 +41,7 @@ const NavBar = styled.nav`
   position: fixed;
   width: 100%;
   z-index: ${themed('zindex.overlay')};
-  
+
   &.menu-open {
     height: 100vh;
     transition: height 300ms ease-in;

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -21,7 +21,13 @@ const mobileBottomMenu = {
 };
 
 if (typeof window !== `undefined`) {
-  SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
+  SmoothScroll('a[href*="#"]', 
+  {
+    easing: 'easeOutQuad', 
+    speed: 700,
+    speedAsDuration: true,
+    offset: '50'
+  });
 };
 
 const MOBILE_NAVIGATION_BREAKPOINT = '767';
@@ -222,9 +228,9 @@ const ContactCallToAction = styled(CallToAction)`
 
 const toggleNoScroll = isOpen => {
   if (!isOpen) {
-    document.body.classList.add('noScroll');
+    document.body.style.overflow = 'hidden';
   } else {
-    document.body.classList.remove('noScroll');
+    document.body.style.overflow = 'auto';
   }
 };
 
@@ -264,38 +270,38 @@ class GlobalNavigation extends React.Component {
             <HomeLink href="/#top" title="Base Two - Home">
               <BaseTwoLogo />
             </HomeLink>
-            <MenuToggle aria-label="Toggle Menu" onClick={this.handleClick}>
+            <MenuToggle aria-label="Toggle Menu" onClickCapture={this.handleClick}>
               <Icon name="menutoggle" />
             </MenuToggle>
           </LogoToggleContainer>
           <NavList>
             <NavItem>
-              <NavLink to="/#services" onClick={this.handleLinkClick}>
+              <NavLink to="/#services" onClickCapture={this.handleLinkClick}>
                 Services
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#clients" onClick={this.handleLinkClick}>
+              <NavLink to="/#clients" onClickCapture={this.handleLinkClick}>
                 Clients
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#team" onClick={this.handleLinkClick}>
+              <NavLink to="/#team" onClickCapture={this.handleLinkClick}>
                 Team
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/jobs" onClick={this.handleLinkClick}>
+              <NavLink to="/jobs" onClickCapture={this.handleLinkClick}>
                 Jobs
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/blog" onClick={this.handleLinkClick}>
+              <NavLink to="/blog" onClickCapture={this.handleLinkClick}>
                 Blog
               </NavLink>
             </NavItem>
             <NavItem>
-              <NavLink to="/#contact-us" onClick={this.handleLinkClick}>
+              <NavLink to="/#contact-us" onClickCapture={this.handleLinkClick}>
                 Contact
               </NavLink>
             </NavItem>

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -269,7 +269,7 @@ class GlobalNavigation extends React.Component {
           </LogoToggleContainer>
           <NavList>
             <NavItem>
-              <NavLink to="/#services" onClick={() => { this.handleLinkClick(); scrollTo('#services');}}>
+              <NavLink to="/#services" onClick={this.handleLinkClick}>
                 Services
               </NavLink>
             </NavItem>

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -20,7 +20,7 @@ const mobileBottomMenu = {
   value: `${em('75px')}`,
 };
 
-SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
+
 
 const MOBILE_NAVIGATION_BREAKPOINT = '767';
 
@@ -247,6 +247,10 @@ class GlobalNavigation extends React.Component {
     this.setState({ isOpen: false });
   };
 
+  componentDidMount() {
+    SmoothScroll('a[href*="#"]', {speed: 700,speedAsDuration: true, easing: 'easeOutQuad'});
+  }
+  
   render() {
     return (
       <NavBar

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -41,10 +41,11 @@ const NavBar = styled.nav`
   position: fixed;
   width: 100%;
   z-index: ${themed('zindex.overlay')};
-
+  
   &.menu-open {
     height: 100vh;
     transition: height 300ms ease-in;
+    touch-action: none;
   }
 
   &.menu-closed {
@@ -226,14 +227,6 @@ const ContactCallToAction = styled(CallToAction)`
   }
 `;
 
-const toggleNoScroll = isOpen => {
-  if (!isOpen) {
-    document.body.style.overflow = 'hidden';
-  } else {
-    document.body.style.overflow = 'auto';
-  }
-};
-
 class GlobalNavigation extends React.Component {
   static defaultProps = {};
 
@@ -246,12 +239,10 @@ class GlobalNavigation extends React.Component {
   };
 
   handleClick = () => {
-    toggleNoScroll(this.state.isOpen);
     this.setState({ isOpen: !this.state.isOpen });
   };
 
   handleLinkClick = () => {
-    toggleNoScroll(this.state.isOpen);
     this.setState({ isOpen: false });
   };
 

--- a/src/components/molecules/GlobalNavigation.jsx
+++ b/src/components/molecules/GlobalNavigation.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { em } from 'polished';
 import windowSize from 'react-window-size';
-import SmoothScroll from 'smooth-scroll';
+import SmoothScroll from 'smooth-scroll/dist/smooth-scroll'
 import {
   A,
   BaseTwoLogo,

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -32,7 +32,7 @@ injectGlobal`
   }
 
   .noScroll > div {
-    height: 100vh;
+    height: 100%;
     overflow: hidden;
 
     ${mediaQuery.small`

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -30,16 +30,6 @@ injectGlobal`
     margin: 0;
     padding: 0;
   }
-
-  .noScroll > div {
-    height: 100%;
-    overflow: hidden;
-
-    ${mediaQuery.small`
-      height: auto;
-      overflow: auto;
-    `};
-  }
 `;
 
 function IndexPage({ clients, services, technologies, team }) {


### PR DESCRIPTION
### feat(site): Smooth scrolling on nav link use
* Add smooth scrolling package that applies to all anchor links
* Change top link to a #top anchor tag

note: the polyfill for this has a conflict with Gatsby SSR, so I'm importing the non-polyfilled script directly.  Browsers without support will stick to jump navigation instead of scroll.

![smoothscrollb2io](https://user-images.githubusercontent.com/6234996/74876398-99f9a880-5331-11ea-9de7-de0b7c0b30c6.gif)

closes #237 


