### PR TITLE
fix(site): Blog header compression on IE11

### DIFF
--- a/src/components/molecules/BlogHeader.jsx
+++ b/src/components/molecules/BlogHeader.jsx
@@ -23,6 +23,7 @@ const BlogHeaderInfoWrapper = styled.div`
   font-size: 1rem;
   font-weight: 400;
   margin-top: ${em('48px')};
+  width: 100%;
   max-width: 1300px;
   padding-bottom: ${em('28px')};
   padding-top: ${em('28px')};


### PR DESCRIPTION
Closes #374

IE11 has some irregular behavior with flexboxes that require explicitly setting the width sometimes.

Before:
![Before](https://user-images.githubusercontent.com/7218166/75723710-ce168700-5caa-11ea-870a-449ad99d3d55.png)


After:
![After](https://user-images.githubusercontent.com/7218166/75723694-c525b580-5caa-11ea-9077-427268ddffc6.png)
