### PR TITLE
fix(site): Fix "View Our Work" button

### DIFF
--- a/src/util/style.js
+++ b/src/util/style.js
@@ -31,14 +31,17 @@ const mediaQuery = {
 };
 
 const containerSizing = css`
-  padding: 0 5%;
+  padding-left: 5%;
+  padding-right: 5%;
 
   ${mediaQuery.medium`
-    padding: 0 2em;
+    padding-left: 2em;
+    padding-right: 2em;
   `};
 
   ${mediaQuery.large`
-    padding: 0 100px;
+    padding-left: 100px;
+    padding-right: 100px;
   `};
 `;
 


### PR DESCRIPTION
Close #477

The wrapper in the Clients section was intended to have a padding at the bottom where a linear gradient would sit. The padding was getting overwritten by the standard container styles, and then linear gradient was in the same space.

To fix this, I changed the common container styles to only set the left and right padding, which is I think what it was intended for.