### PR TITLE
fix(site): Streamline polyfills

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,10 +1,12 @@
 import wrapWithGlobalStyles from './wrap-with-global-styles';
 
 export const onClientEntry = () => {
-  // Polyfills:
-  require('whatwg-fetch');
-  require('./src/util/prism-languages');
-  Object.assign = require('object-assign');
+  if (!CustomEvent) {
+    require('custom-event-polyfill');
+  }
+  if (!document.getElementsByTagName('html')[0].closest) {
+    require('element-closest-polyfill');
+  }
 };
 
 export const wrapRootElement = wrapWithGlobalStyles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@b2io/base2.io",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7308,6 +7308,11 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "custom-event-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
+    },
     "cwebp-bin": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",
@@ -8260,6 +8265,11 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "element-closest-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/element-closest-polyfill/-/element-closest-polyfill-1.0.0.tgz",
+      "integrity": "sha512-WNp+gd+xG4JVC6wjeFt8KHoaS4TD0ppDhHjgKdWXmLAUz7KPrxTxxS0SJPBKS3qE/hpl8cNmsA08izLVIItblg=="
     },
     "elliptic": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@mdx-js/react": "^1.5.7",
     "babel-plugin-styled-components": "^1.10.0",
     "core-js": "^2.6.11",
+    "custom-event-polyfill": "^1.0.7",
+    "element-closest-polyfill": "^1.0.0",
     "gatsby": "^2.13.50",
     "gatsby-image": "^2.1.2",
     "gatsby-link": "^2.1.1",
@@ -31,7 +33,6 @@
     "lodash": "^4.17.15",
     "luxon": "^1.4.2",
     "nanoid": "^1.2.6",
-    "object-assign": "^4.1.1",
     "polished": "^2.2.0",
     "prism-react-renderer": "^1.0.2",
     "prismjs": "^1.19.0",
@@ -47,8 +48,7 @@
     "sharp": "^0.20.8",
     "smooth-scroll": "^16.1.2",
     "styled-components": "^4.4.1",
-    "supports-webp": "^1.0.7",
-    "whatwg-fetch": "^3.0.0"
+    "supports-webp": "^1.0.7"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.8.7",

--- a/src/html.jsx
+++ b/src/html.jsx
@@ -43,7 +43,6 @@ function Html({
         />
         <title>Base Two</title>
         {headComponents}
-        <script src="https://cdn.polyfill.io/v2/polyfill.min.js" />
       </head>
       <body {...bodyAttributes}>
         {preBodyComponents}


### PR DESCRIPTION
Close #393, Close #371

Most of the polyfills we need are taken care of by Babel, [Gatsby](https://www.gatsbyjs.org/docs/browser-support/), and BrowsersList. Other than that, `smooth-scroll` requires `CustomEvent` and `Element.closest`.

Tested in Safari (Mac/iOS), IE11, Firefox, and Chrome.