### PR TITLE
chore: index import sort order

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,9 @@
 export * from './CTA';
-export * from './Header';
 export * from './Heading';
 export * from './icons';
-export * from './Layout';
-export * from './MobileMenu';
 export * from './Text';
+
+// Order based on dependent usage:
+export * from './MobileMenu';
+export * from './Header';
+export * from './Layout';


### PR DESCRIPTION
Closes B2-64

Adjust the order of imports based on their dependent usage rather than
simply by alphabetical order.