### PR TITLE
adjust padding for HomeHero on smaller screens

### DIFF
--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -179,19 +179,13 @@ export const HomeHero: FC = () => {
     );
   });
 
-  const calculatedPaddingTopBottom = cssClamp([3, 'xs'], [10.5, 'lg']);
-  const calculatedPaddingRightLeft = cssClamp(
-    [0, 'xs'],
-    [1, 'smMobile'],
-    [10.5, 'lg'],
-  );
-
   return (
     <div
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${calculatedPaddingTopBottom} ${calculatedPaddingRightLeft};
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
+          ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -184,7 +184,8 @@ export const HomeHero: FC = () => {
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])} // formatting hack
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
+          // ignore vscode-styled-components error
           ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
         position: relative;
         text-align: center;

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -179,14 +179,19 @@ export const HomeHero: FC = () => {
     );
   });
 
+  const calculatedPaddingTopBottom = cssClamp([3, 'xs'], [10.5, 'lg']);
+  const calculatedPaddingRightLeft = cssClamp(
+    [0, 'xs'],
+    [1, 'smMobile'],
+    [10.5, 'lg'],
+  );
+
   return (
     <div
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
-          ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
-        /* don't freakin wrap */
+        padding: ${calculatedPaddingTopBottom} ${calculatedPaddingRightLeft};
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -184,8 +184,8 @@ export const HomeHero: FC = () => {
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
-          ${cssClamp([1.5, 'xs'], [5.25, 'lg'])};
+        ${cssClamp([1.5, 'xs'], [5.25, 'lg'])};
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])};
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -186,7 +186,7 @@ export const HomeHero: FC = () => {
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
         padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
           // ignore vscode-styled-components error
-          ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
+          ${cssClamp([0, 'xs'], [1, 'smMobile'], [5.25, 'lg'])};
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -184,8 +184,8 @@ export const HomeHero: FC = () => {
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        ${cssClamp([1.5, 'xs'], [5.25, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])};
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
+          ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -184,7 +184,7 @@ export const HomeHero: FC = () => {
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])} // annoying but necessary
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])} // formatting hack
           ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
         position: relative;
         text-align: center;

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -186,6 +186,7 @@ export const HomeHero: FC = () => {
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
         padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
           ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
+        /* don't freakin wrap */
         position: relative;
         text-align: center;
 

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -184,7 +184,7 @@ export const HomeHero: FC = () => {
       css={css`
         display: grid;
         gap: ${cssClamp([2, 'xs'], [1.5, 'lg'])};
-        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])}
+        padding: ${cssClamp([3, 'xs'], [10.5, 'lg'])} // annoying but necessary
           ${cssClamp([0, 'xs'], [1, 'smMobile'], [10.5, 'lg'])};
         position: relative;
         text-align: center;


### PR DESCRIPTION
Closes [B2-75](https://b2io.atlassian.net/browse/B2-75)

- adjusted padding to address header alignment on smaller screens

NOTES: 

- Discussed the implementation of these changes with Ashley, Tony, and Drew

**Next Steps**
- [ ] discuss adding min-width to body after upcoming discussion on browser size support



<details>
<summary>mobile</summary>

![Screen Shot 2021-04-28 at 10 34 34 AM](https://user-images.githubusercontent.com/17680907/116423026-4e347000-a80e-11eb-84fa-4f3bc78a98ac.png)


</details>

<details>
<summary>tablet</summary>

![Screen Shot 2021-04-28 at 10 34 55 AM](https://user-images.githubusercontent.com/17680907/116423040-52f92400-a80e-11eb-8583-6fabb4866c87.png)


</details>

<details>
<summary>desktop</summary>

![Screen Shot 2021-04-28 at 10 35 21 AM](https://user-images.githubusercontent.com/17680907/116423075-5a203200-a80e-11eb-8031-2f845828739c.png)

</details>