### PR TITLE
Create Icon Card component

### DIFF
--- a/src/components/IconCard.stories.tsx
+++ b/src/components/IconCard.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, Story } from '@storybook/react';
+
+import { IconCard, IconCardProps } from './IconCard';
+
+export default {
+  component: IconCard,
+  title: 'Components/IconCard',
+} as Meta;
+
+export const IconCardStory: Story<IconCardProps & { text: string }> = ({
+  text,
+  ...args
+}) => {
+  return <IconCard {...args}>{text}</IconCard>;
+};
+
+IconCardStory.args = {
+  heading: 'Fully managed ',
+  icon: 'fullyManaged',
+  text:
+    'Our developers are skilled at handling the entire project pipeline while making sure you’re satisfied at each step of our process. A dedicated contact within our team is always available to answer your questions, and daily standups provide an opportunity for you to weigh in on our progress.',
+};
+IconCardStory.storyName = 'IconCard';

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -65,11 +65,7 @@ export const IconCard: FC<IconCardProps> = ({ children, icon, heading }) => {
   const iconSelected = icon;
 
   return (
-    <div
-      css={css`
-        width: 50%;
-      `}
-    >
+    <div>
       <IconImage className={icon}>{IconList[iconSelected]}</IconImage>
       <Heading
         as="h3"

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -39,10 +39,13 @@ export type IconCardProps = {
   heading: string;
 };
 
-const IconImage = styled.svg`
+const IconImage = styled.div`
   height: 3rem;
   margin-bottom: ${spacing.xxs};
-  width: 3rem;
+
+  svg {
+    width: auto;
+  }
 `;
 
 const IconList = {

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { FC } from 'react';
+
+import { spacing } from '~/theme';
+import { Heading, Text } from '~/components';
+
+import {
+  BusinessIcon,
+  CommunityIcon,
+  DeliveryIcon,
+  DeveloperIcon,
+  DiscoveryIcon,
+  EmbeddedIcon,
+  EmpathyIcon,
+  ExecutionIcon,
+  FullyManagedIcon,
+  SupportIcon,
+  SustainabilityIcon,
+  TransparencyIcon,
+} from './icons';
+
+type Icon =
+  | 'business'
+  | 'community'
+  | 'delivery'
+  | 'developer'
+  | 'discovery'
+  | 'embedded'
+  | 'empathy'
+  | 'execution'
+  | 'fullyManaged'
+  | 'support'
+  | 'sustainability'
+  | 'transparency';
+
+export type IconCardProps = {
+  icon: Icon;
+  heading: string;
+};
+
+const IconImage = styled.div(`
+  svg {
+    width: 50px;
+    margin-bottom: ${spacing.xxs}
+  }
+`);
+
+const IconList = {
+  business: <BusinessIcon />,
+  community: <CommunityIcon />,
+  delivery: <DeliveryIcon />,
+  developer: <DeveloperIcon />,
+  discovery: <DiscoveryIcon />,
+  embedded: <EmbeddedIcon />,
+  empathy: <EmpathyIcon />,
+  execution: <ExecutionIcon />,
+  fullyManaged: <FullyManagedIcon />,
+  support: <SupportIcon />,
+  sustainability: <SustainabilityIcon />,
+  transparency: <TransparencyIcon />,
+};
+
+export const IconCard: FC<IconCardProps> = ({ children, icon, heading }) => {
+  const iconSelected = icon;
+
+  return (
+    <div
+      css={css`
+        width: 50%;
+      `}
+    >
+      <IconImage className={icon}>{IconList[iconSelected]}</IconImage>
+      <Heading
+        as="h3"
+        color="coral"
+        variant="h3"
+        css={css`
+          margin-bottom: ${spacing.xs};
+        `}
+      >
+        {heading}
+      </Heading>
+      <Text>{children}</Text>
+    </div>
+  );
+};

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -39,12 +39,11 @@ export type IconCardProps = {
   heading: string;
 };
 
-const IconImage = styled.div(`
-  svg {
-    width: 50px;
-    margin-bottom: ${spacing.xxs}
-  }
-`);
+const IconImage = styled.svg`
+  height: 3rem;
+  margin-bottom: ${spacing.xxs};
+  width: 3rem;
+`;
 
 const IconList = {
   business: <BusinessIcon />,

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -61,11 +61,16 @@ const IconList = {
   transparency: <TransparencyIcon />,
 };
 
-export const IconCard: FC<IconCardProps> = ({ children, icon, heading }) => {
+export const IconCard: FC<IconCardProps> = ({
+  children,
+  icon,
+  heading,
+  ...props
+}) => {
   const iconSelected = icon;
 
   return (
-    <div>
+    <div {...props}>
       <IconImage className={icon}>{IconList[iconSelected]}</IconImage>
       <Heading
         as="h3"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './Container';
 export * from './Header';
 export * from './Heading';
 export * from './HomePage';
+export * from './IconCard';
 export * from './icons';
 export * from './Layout';
 export * from './Link';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,6 +3,7 @@ import { spacing } from './spacing';
 import { linkVariants, textVariants } from './typography';
 
 export * from './breakpoints';
+export * from './spacing';
 export type { ThemeColor } from './colors';
 export type { ThemeLinkVariants, ThemeTextVariants } from './typography';
 export * from './util';


### PR DESCRIPTION
[[B2-5](https://b2io.atlassian.net/browse/B2-5)]

- Create Icon Card component to take in an icon type, heading, and text.

Pages that use the Icon Card component:
<details>
<summary>Culture</summary>
<img width="997" alt="Screen Shot 2021-05-07 at 10 45 46 AM" src="https://user-images.githubusercontent.com/5387554/117468710-f50dc000-af22-11eb-8845-820685a31dc1.png"></details>

<details>
<summary>Approach</summary>
![Screen Shot 2021-05-07 at 10 50 38 AM](https://user-images.githubusercontent.com/5387554/117468858-1c648d00-af23-11eb-8575-addc7168d469.png)</details>

<details>
<summary>Work</summary>
![Screen Shot 2021-05-07 at 10 52 21 AM](https://user-images.githubusercontent.com/5387554/117468878-225a6e00-af23-11eb-8cd5-55627f2ab7ea.png)</details>
