### PR TITLE
Standardize import patterns

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,13 +8,21 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
     "prettier",
     "prettier/@typescript-eslint"
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      }
+    },
     "react": {
       "version": "detect"
     }
@@ -33,6 +41,23 @@
     ],
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-var-requires": 0,
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "caseInsensitive": true, "order": "asc" },
+        "groups": [
+          ["builtin", "internal", "external"],
+          ["parent", "sibling"],
+          "index",
+          "object"
+        ],
+        "newlines-between": "always",
+        "pathGroups": [
+          { "group": "parent", "pattern": "~/**", "position": "before" }
+        ]
+      }
+    ],
+    "import/newline-after-import": 1,
     "no-console": [
       2,
       {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,7 @@ import { css, Global, ThemeProvider } from '@emotion/react';
 
 import roobertGX from '../public/RoobertGX.woff2';
 import roobertItalicGX from '../public/RoobertItalicGX.woff2';
-import theme from '../src/theme';
+import theme, { colors } from '../src/theme';
 
 export const decorators = [
   (Story) => (
@@ -48,8 +48,8 @@ export const parameters = {
   backgrounds: {
     default: 'dark',
     values: [
-      { name: 'dark', value: theme.colors.darkBlue },
-      { name: 'light', value: theme.colors.offWhite },
+      { name: 'dark', value: colors.darkBlue },
+      { name: 'light', value: colors.offWhite },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
         "babel-loader": "^8.2.2",
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^7.2.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.23.3",
         "eslint-plugin-react": "^7.22.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^26.6.3",
@@ -9125,6 +9127,12 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "node_modules/@types/markdown-to-jsx": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz",
@@ -10116,19 +10124,22 @@
       "dev": true
     },
     "node_modules/array-includes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
-      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "get-intrinsic": "^1.0.1",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.5"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-union": {
@@ -14000,6 +14011,335 @@
         "eslint-config-prettier": "bin/cli.js"
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
+      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "pkg-dir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
+      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.1",
+        "find-up": "^2.0.0",
+        "has": "^1.0.3",
+        "is-core-module": "^2.4.0",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.3",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-import/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
@@ -15488,13 +15828,16 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-orientation": {
@@ -16780,11 +17123,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -19360,6 +19706,52 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -21048,18 +21440,21 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
-      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.18.0-next.2",
         "has": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/objectorarray": {
@@ -22290,17 +22685,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/promise.prototype.finally/node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
       }
     },
     "node_modules/promise.prototype.finally/node_modules/has-symbols": {
@@ -26044,6 +26428,39 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -36545,6 +36962,12 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/markdown-to-jsx": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz",
@@ -37442,15 +37865,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
-      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "get-intrinsic": "^1.0.1",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.5"
       }
     },
@@ -40961,6 +41384,268 @@
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
       "dev": true
     },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-import-resolver-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
+      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
+      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.1",
+        "find-up": "^2.0.0",
+        "has": "^1.0.3",
+        "is-core-module": "^2.4.0",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.3",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+          "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
@@ -42091,9 +42776,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -43175,9 +43860,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -45237,6 +45922,42 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -46706,14 +47427,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
-      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.18.0-next.2",
         "has": "^1.0.3"
       }
     },
@@ -47750,17 +48471,6 @@
             "string.prototype.trimend": "^1.0.4",
             "string.prototype.trimstart": "^1.0.4",
             "unbox-primitive": "^1.0.0"
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
           }
         },
         "has-symbols": {
@@ -51002,6 +51712,35 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "babel-loader": "^8.2.2",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-react": "^7.22.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",

--- a/src/components/ApproachPage/HowWeBuild.tsx
+++ b/src/components/ApproachPage/HowWeBuild.tsx
@@ -1,10 +1,8 @@
-import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { FC } from 'react';
+import styled from '@emotion/styled';
+import type { FC } from 'react';
 
 import { Heading, IconCard, IconCardGrid, Link } from '~/components';
-import { DynamicImage } from '../DynamicImage';
-
 import {
   atMinDesktop,
   atMinLargeDesktop,
@@ -13,6 +11,8 @@ import {
   cssClamp,
   spacing,
 } from '~/theme';
+
+import { DynamicImage } from '../DynamicImage';
 
 const imageDimensionsCalc = cssClamp([25.625, 'mobile'], [69.5, 'tablet']);
 

--- a/src/components/ApproachPage/HowWeEngage.tsx
+++ b/src/components/ApproachPage/HowWeEngage.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import { Heading, IconCard, Link } from '~/components';
 import { spacing, atMinTablet, atMinXL } from '~/theme';
+
 import { IconCardGrid } from '../IconCard';
 
 export const HowWeEngage: FC = (props) => {

--- a/src/components/ApproachPage/index.tsx
+++ b/src/components/ApproachPage/index.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import React, { FC } from 'react';
+
 import { Layout, PageHero, QuotedImage } from '~/components';
 import { atMinTablet, cssClamp, spacing } from '~/theme';
 

--- a/src/components/CulturePage/AvailablePositions.tsx
+++ b/src/components/CulturePage/AvailablePositions.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import type { FC } from 'react';
+
 import { atMinXL, spacing } from '~/theme';
 
 import { Heading } from '../Heading';

--- a/src/components/CulturePage/OurBlog.tsx
+++ b/src/components/CulturePage/OurBlog.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import type { FC } from 'react';
+
 import { atMinXL, spacing } from '~/theme';
 
 import { Heading } from '../Heading';

--- a/src/components/CulturePage/OurCulture.tsx
+++ b/src/components/CulturePage/OurCulture.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { FC } from 'react';
+import type { FC } from 'react';
+
 import { atMinXL, spacing } from '~/theme';
 
 import { Heading } from '../Heading';

--- a/src/components/CulturePage/index.tsx
+++ b/src/components/CulturePage/index.tsx
@@ -1,14 +1,15 @@
 import { css } from '@emotion/react';
 import type { FC } from 'react';
 
+import { atMinDesktop, atMinTablet, spacing } from '~/theme';
+
 import { Layout } from '../Layout';
 import { PageHero } from '../PageHero';
+import { TeamCardList } from '../TeamCardList';
+import { TeamHero } from '../TeamHero';
 import { AvailablePositions } from './AvailablePositions';
 import { OurBlog } from './OurBlog';
 import { OurCulture } from './OurCulture';
-import { TeamCardList } from '../TeamCardList';
-import { TeamHero } from '../TeamHero';
-import { atMinDesktop, atMinTablet, spacing } from '~/theme';
 
 export const CulturePage: FC = () => {
   return (

--- a/src/components/DynamicImage.tsx
+++ b/src/components/DynamicImage.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import type { FC } from 'react';
+
 import { bp } from '~/theme';
 import { BpMapPair } from '~/types';
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,13 @@
-import { css, useTheme } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { FC } from 'react';
 
-import { atMinTablet, atMinLg } from '~/theme';
+import { atMinTablet, atMinLg, colors, spacing } from '~/theme';
+
 import { Container } from './Container';
+import { LogoIcon } from './icons';
 import { Link } from './Link';
-import { LogoIcon } from './icons/LogoIcon';
-import Text from './Text';
+import { Text } from './Text';
 
 const FooterWrapper = styled.div`
   margin-left: 1.688rem;
@@ -75,8 +76,8 @@ const Nav = styled.nav`
 `;
 
 const ContactBlock = styled.address`
-  margin-top: ${({ theme }) => theme.spacing.xxl};
-  padding-bottom: ${({ theme }) => theme.spacing.lg};
+  margin-top: ${spacing.xxl};
+  padding-bottom: ${spacing.lg};
 
   ${atMinTablet} {
     margin-top: 0;
@@ -93,7 +94,7 @@ const ContactBlock = styled.address`
 
 const ContactLink = styled(Link)`
   display: block;
-  margin-bottom: ${({ theme }) => theme.spacing.md};
+  margin-bottom: ${spacing.md};
 
   &:last-child {
     margin-bottom: 0;
@@ -106,7 +107,7 @@ const ContactLink = styled(Link)`
     }
 
     ${atMinTablet} {
-      margin-bottom: ${({ theme }) => theme.spacing.sm};
+      margin-bottom: ${spacing.sm};
     }
   }
 
@@ -120,12 +121,11 @@ const ContactLink = styled(Link)`
 `;
 
 export const Footer: FC = (prop) => {
-  const theme = useTheme();
   return (
     <Container
       as="footer"
       css={css`
-        background-color: ${theme.colors.darkBlueAlt};
+        background-color: ${colors.darkBlueAlt};
 
         ${atMinTablet} {
           background-color: unset;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,12 +2,13 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import type { FC } from 'react';
 
-import { atMinTablet, atMinSm, atMinXXL } from '~/theme';
-import { Link } from './Link';
+import { atMinTablet, atMinSm, atMinXXL, colors, spacing } from '~/theme';
+
 import { Container } from './Container';
 import { LogoWithName } from './icons';
+import { Link } from './Link';
 import { MobileMenu } from './MobileMenu';
 
 const Root = styled.header`
@@ -28,16 +29,16 @@ const Content = styled(Container)`
   align-items: center;
   display: flex;
   justify-content: space-between;
-  padding-bottom: ${({ theme }) => theme.spacing.xxl};
-  padding-top: ${({ theme }) => theme.spacing.sm};
+  padding-bottom: ${spacing.xxl};
+  padding-top: ${spacing.sm};
 
   ${atMinTablet} {
-    padding-bottom: ${({ theme }) => theme.spacing.lg};
-    padding-top: ${({ theme }) => theme.spacing.md};
+    padding-bottom: ${spacing.lg};
+    padding-top: ${spacing.md};
   }
   ${atMinXXL} {
-    padding-bottom: ${({ theme }) => theme.spacing.xxl};
-    padding-top: ${({ theme }) => theme.spacing.md};
+    padding-bottom: ${spacing.xxl};
+    padding-top: ${spacing.md};
   }
 `;
 
@@ -54,7 +55,7 @@ const Nav = styled.nav`
   }
 
   li {
-    margin-right: ${({ theme }) => theme.spacing.lg};
+    margin-right: ${spacing.lg};
     &:last-child {
       margin-right: 0;
     }
@@ -68,7 +69,7 @@ const Nav = styled.nav`
     }
 
     &.active::after {
-      background-color: ${({ theme }) => theme.colors.action};
+      background-color: ${colors.action};
     }
   }
 `;

--- a/src/components/Heading.stories.tsx
+++ b/src/components/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 
 import { Heading, HeadingProps } from './Heading';
 

--- a/src/components/HomePage/BuiltForResults.tsx
+++ b/src/components/HomePage/BuiltForResults.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import NextImage from 'next/image';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import { Heading, Link, Text } from '~/components';
 import theme, {
@@ -12,7 +12,7 @@ import theme, {
   cssClamp,
   spacing,
 } from '~/theme';
-import { ImageProps } from '~/types';
+import type { ImageProps } from '~/types';
 
 const largeImageHeightCalc = cssClamp([26.625, 'tablet'], [50, 'desktop']);
 const imageTopCalc = cssClamp(

--- a/src/components/HomePage/DesignedForHumans.tsx
+++ b/src/components/HomePage/DesignedForHumans.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import NextImage from 'next/image';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import { Heading, Link, Text } from '~/components';
 import theme, { atMinDesktop, atMinTablet, cssClamp } from '~/theme';
-import { ImageProps } from '~/types';
+import type { ImageProps } from '~/types';
 
 const largeImageHeightCalc = cssClamp([26.625, 'tablet'], [50, 'desktop']);
 const imageTopCalc = cssClamp(

--- a/src/components/HomePage/FeaturedCaseStudy.tsx
+++ b/src/components/HomePage/FeaturedCaseStudy.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import NextImage from 'next/image';
-import { spacing } from '~/theme/spacing';
 import { FC } from 'react';
 
 import { Heading, Link, Text } from '~/components';
-import { atMinSm, atMinTablet, atMinXL, cssClamp } from '~/theme';
+import { atMinSm, atMinTablet, atMinXL, cssClamp, spacing } from '~/theme';
 
 const GUTTER_SHIFT = '1.375rem';
 

--- a/src/components/HomePage/FueledByCuriosity.tsx
+++ b/src/components/HomePage/FueledByCuriosity.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import NextImage from 'next/image';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import { Heading, Link, Text } from '~/components';
 import theme, { atMinTablet, atMinXL, cssClamp } from '~/theme';
-import { ImageProps } from '~/types';
+import type { ImageProps } from '~/types';
 
 const imageDimensionsCalc = cssClamp([32, 'mobile'], [69.5, 'tablet']);
 const imageTopCalc = cssClamp([1.85, 'mobile'], [0, 'tablet']);

--- a/src/components/HomePage/HomeHero.tsx
+++ b/src/components/HomePage/HomeHero.tsx
@@ -11,7 +11,7 @@ import type { SpringOptions } from 'popmotion';
 import { FC, RefObject, useEffect, useRef } from 'react';
 
 import { Heading, Text } from '~/components';
-import theme, { atMinLg, cssClamp, interpolateColors } from '~/theme';
+import { atMinLg, colors, cssClamp, interpolateColors } from '~/theme';
 
 const useMouseAnimation = <T extends HTMLElement>(
   config?: SpringOptions,
@@ -153,7 +153,7 @@ const Line: FC<LineProps> = ({ index, mouse }) => {
 };
 
 const STOP_COLORS = interpolateColors(
-  [theme.colors.midBlue, theme.colors.coral, theme.colors.midBlue],
+  [colors.midBlue, colors.coral, colors.midBlue],
   4,
 );
 
@@ -191,7 +191,7 @@ export const HomeHero: FC = (props) => {
         text-align: center;
 
         & * {
-          text-shadow: 0.25rem 0.25rem 0.375rem ${theme.colors.darkBlue};
+          text-shadow: 0.25rem 0.25rem 0.375rem ${colors.darkBlue};
           z-index: 1;
         }
 

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -1,8 +1,8 @@
-import { FC } from 'react';
-import { Layout } from '~/components';
-import { spacing } from '~/theme/spacing';
 import { css } from '@emotion/react';
-import { atMinTablet, atMinXL, cssClamp } from '~/theme';
+import type { FC } from 'react';
+
+import { Layout } from '~/components';
+import { atMinTablet, atMinXL, cssClamp, spacing } from '~/theme';
 
 import { BuiltForResults } from './BuiltForResults';
 import { DesignedForHumans } from './DesignedForHumans';

--- a/src/components/IconCard.stories.tsx
+++ b/src/components/IconCard.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 
 import { IconCard, IconCardProps } from './IconCard';
 

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { Children, cloneElement, ElementType, FC, ReactElement } from 'react';
 
-import { atMinTablet, spacing } from '~/theme';
 import { Heading, Text } from '~/components';
+import { atMinTablet, spacing } from '~/theme';
 
 import {
   BusinessIcon,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,13 +2,13 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
 import Head from 'next/head';
-import React, { FC } from 'react';
-
-import { Container } from './Container';
-import { Header } from './Header';
-import { Footer } from './Footer';
+import type { FC } from 'react';
 
 import { cssClamp } from '~/theme';
+
+import { Container } from './Container';
+import { Footer } from './Footer';
+import { Header } from './Header';
 
 const Root = styled.div`
   overflow: hidden;

--- a/src/components/Link.stories.tsx
+++ b/src/components/Link.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 
 import { Link, LinkProps } from './Link';
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import NextLink from 'next/link';
-import { FC } from 'react';
+import type { FC } from 'react';
 import { variant } from 'styled-system';
 
 import { ThemeLinkVariants } from '~/theme';

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -2,11 +2,13 @@ import styled from '@emotion/styled';
 import React, { FC } from 'react';
 import { useLockBodyScroll, useToggle } from 'react-use';
 
-import { Link } from './Link';
+import { colors, spacing } from '~/theme';
+
 import { MenuIcon } from './icons';
+import { Link } from './Link';
 
 const Menu = styled.div`
-  background-color: ${({ theme }) => theme.colors.workThumbnailBg};
+  background-color: ${colors.workThumbnailBg};
   height: 100%;
   left: 0;
   opacity: 0;
@@ -39,14 +41,13 @@ const Nav = styled.nav`
   }
 
   li {
-    margin-bottom: ${({ theme }) => theme.spacing.xs};
+    margin-bottom: ${spacing.xs};
   }
 `;
 
 const ContactLink = styled(Link)`
   display: table;
-  margin: ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.lg}
-    0;
+  margin: ${spacing.lg} ${spacing.lg} 0;
 `;
 
 export const MobileMenu: FC = ({ ...props }) => {

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import {
   atMinLg,
@@ -9,8 +9,9 @@ import {
   atMinXL,
   cssClamp,
 } from '~/theme';
-import { Heading } from './Heading';
+
 import { DynamicImage, DynamicImageProps } from './DynamicImage';
+import { Heading } from './Heading';
 
 type PageHeroProps = DynamicImageProps & {
   text: string;

--- a/src/components/QuotedImage.tsx
+++ b/src/components/QuotedImage.tsx
@@ -1,19 +1,20 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { FC } from 'react';
+import type { FC } from 'react';
 
-import { Heading } from './Heading';
-import { Text } from './Text';
 import {
   atMaxMd,
   atMinDesktop,
   atMinMobile,
   atMinTablet,
   atMinXL,
-} from '~/theme/breakpoints';
-import { spacing } from '~/theme/spacing';
-import { cssClamp } from '~/theme/util';
+  cssClamp,
+  spacing,
+} from '~/theme';
+
 import { DynamicImage, DynamicImageProps } from './DynamicImage';
+import { Heading } from './Heading';
+import { Text } from './Text';
 
 type QuotedImageProps = DynamicImageProps & {
   company: string;

--- a/src/components/TeamCardList.tsx
+++ b/src/components/TeamCardList.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import team from '~/team.json';
-import theme, { atMinDesktop, atMinSm, atMinXL, spacing } from '~/theme';
+import { atMinDesktop, atMinSm, atMinXL, colors, spacing } from '~/theme';
+
 import { TeamMemberCard } from './TeamMemberCard';
 
 const TeamMasonry = styled.section`
@@ -59,7 +60,7 @@ const TeamMasonry = styled.section`
     display: none;
 
     ${atMinDesktop} {
-      background-color: ${theme.colors.darkBlueAlt};
+      background-color: ${colors.darkBlueAlt};
       border-bottom: 1px solid #979797;
       border-top: 1px solid #979797;
       bottom: 0;

--- a/src/components/TeamHero.tsx
+++ b/src/components/TeamHero.tsx
@@ -1,11 +1,17 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import type { FC } from 'react';
 
-import { FC } from 'react';
-import { Heading } from './Heading';
-import { atMinLg, atMinDesktop, atMinLargeDesktop } from '~/theme/breakpoints';
-import { cssClamp, spacing } from '../theme';
+import {
+  atMinLg,
+  atMinDesktop,
+  atMinLargeDesktop,
+  cssClamp,
+  spacing,
+} from '~/theme';
+
 import { DynamicImage, DynamicImageProps } from './DynamicImage';
+import { Heading } from './Heading';
 
 type TeamHeroProps = DynamicImageProps & {
   text: string;

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
 import NextImage from 'next/image';
-import { FC } from 'react';
-import { colors } from '~/theme/colors';
+import type { FC } from 'react';
+
+import { atMinSm, atMinTablet, colors, spacing } from '~/theme';
+import type { ImageProps } from '~/types';
 
 import { Heading } from './Heading';
 import { Text } from './Text';
-import { atMinSm, atMinTablet } from '~/theme';
-import { spacing } from '~/theme/spacing';
-import { ImageProps } from '~/types';
 
 type TeamMemberCardProps = ImageProps & {
   name: string;

--- a/src/components/Text.stories.tsx
+++ b/src/components/Text.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 
 import { Text, TextProps } from './Text';
 

--- a/src/components/icons/BusinessIcon.stories.tsx
+++ b/src/components/icons/BusinessIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { BusinessIcon } from '..';
-import { SvgProps } from './types';
+import { BusinessIcon } from './BusinessIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: BusinessIcon,

--- a/src/components/icons/BusinessIcon.tsx
+++ b/src/components/icons/BusinessIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const BusinessIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/Community.stories.tsx
+++ b/src/components/icons/Community.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { CommunityIcon } from '.';
-import { SvgProps } from './types';
+import { CommunityIcon } from './CommunityIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: CommunityIcon,

--- a/src/components/icons/CommunityIcon.tsx
+++ b/src/components/icons/CommunityIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const CommunityIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/DeliveryIcon.stories.tsx
+++ b/src/components/icons/DeliveryIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { DeliveryIcon } from '..';
-import { SvgProps } from './types';
+import { DeliveryIcon } from './DeliveryIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: DeliveryIcon,

--- a/src/components/icons/DeliveryIcon.tsx
+++ b/src/components/icons/DeliveryIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const DeliveryIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/DeveloperIcon.stories.tsx
+++ b/src/components/icons/DeveloperIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { DeveloperIcon } from '..';
-import { SvgProps } from './types';
+import { DeveloperIcon } from './DeveloperIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: DeveloperIcon,

--- a/src/components/icons/DeveloperIcon.tsx
+++ b/src/components/icons/DeveloperIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const DeveloperIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/DiscoveryIcon.stories.tsx
+++ b/src/components/icons/DiscoveryIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { DiscoveryIcon } from '..';
-import { SvgProps } from './types';
+import { DiscoveryIcon } from './DiscoveryIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: DiscoveryIcon,

--- a/src/components/icons/DiscoveryIcon.tsx
+++ b/src/components/icons/DiscoveryIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const DiscoveryIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/EmbeddedIcon.stories.tsx
+++ b/src/components/icons/EmbeddedIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { EmbeddedIcon } from '..';
-import { SvgProps } from './types';
+import { EmbeddedIcon } from './EmbeddedIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: EmbeddedIcon,

--- a/src/components/icons/EmbeddedIcon.tsx
+++ b/src/components/icons/EmbeddedIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const EmbeddedIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/EmpathyIcon.stories.tsx
+++ b/src/components/icons/EmpathyIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { EmpathyIcon } from '..';
-import { SvgProps } from './types';
+import { EmpathyIcon } from './EmpathyIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: EmpathyIcon,

--- a/src/components/icons/EmpathyIcon.tsx
+++ b/src/components/icons/EmpathyIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const EmpathyIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/ExecutionIcon.stories.tsx
+++ b/src/components/icons/ExecutionIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { ExecutionIcon } from '..';
-import { SvgProps } from './types';
+import { ExecutionIcon } from './ExecutionIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: ExecutionIcon,

--- a/src/components/icons/ExecutionIcon.tsx
+++ b/src/components/icons/ExecutionIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const ExecutionIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/FullyManagedIcon.stories.tsx
+++ b/src/components/icons/FullyManagedIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { FullyManagedIcon } from '..';
-import { SvgProps } from './types';
+import { FullyManagedIcon } from './FullyManagedIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: FullyManagedIcon,

--- a/src/components/icons/FullyManagedIcon.tsx
+++ b/src/components/icons/FullyManagedIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const FullyManagedIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/Logo.stories.tsx
+++ b/src/components/icons/Logo.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { LogoIcon, LogoWithName } from './';
-import { SvgProps } from './types';
+import { LogoIcon, LogoWithName } from './LogoIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: LogoIcon,

--- a/src/components/icons/LogoIcon.tsx
+++ b/src/components/icons/LogoIcon.tsx
@@ -1,7 +1,7 @@
 import { useId } from '@react-aria/utils';
 import type { FC } from 'react';
 
-import { SvgProps } from './types';
+import type { SvgProps } from './types';
 
 export const LogoIcon: FC<SvgProps> = ({
   height = '100%',

--- a/src/components/icons/MenuIcon.tsx
+++ b/src/components/icons/MenuIcon.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import React, { FC } from 'react';
 
+import { colors } from '~/theme';
+
 export interface MenuIconProps {
   showClose?: boolean;
 }
@@ -11,7 +13,7 @@ const Container = styled.div`
   position: relative;
   width: 24px;
   span {
-    background-color: ${({ theme }) => theme.colors.offWhite};
+    background-color: ${colors.offWhite};
     height: 1px;
     position: absolute;
     right: 0;

--- a/src/components/icons/SupportIcon.stories.tsx
+++ b/src/components/icons/SupportIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { SupportIcon } from '..';
-import { SvgProps } from './types';
+import { SupportIcon } from './SupportIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: SupportIcon,

--- a/src/components/icons/SustainabilityIcon.stories.tsx
+++ b/src/components/icons/SustainabilityIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { SustainabilityIcon } from '..';
-import { SvgProps } from './types';
+import { SustainabilityIcon } from './SustainabilityIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: SustainabilityIcon,

--- a/src/components/icons/TransparencyIcon.stories.tsx
+++ b/src/components/icons/TransparencyIcon.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, Story } from '@storybook/react';
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import { TransparencyIcon } from './';
-import { SvgProps } from './types';
+import { TransparencyIcon } from './TransparencyIcon';
+import type { SvgProps } from './types';
 
 export default {
   component: TransparencyIcon,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
 
 import { Layout } from '~/components';
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,12 @@
+import 'normalize.css';
 import { css, Global, ThemeProvider } from '@emotion/react';
+import { SSRProvider } from '@react-aria/ssr';
 import { AnimatePresence, AnimateSharedLayout } from 'framer-motion';
 import { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
-import { FC } from 'react';
+import type { FC } from 'react';
 
-import theme from '~/theme';
-import 'normalize.css';
+import theme, { colors } from '~/theme';
 
 const handleExitComplete = () => {
   if (typeof window !== 'undefined') {
@@ -31,11 +32,13 @@ const CustomApp: FC<AppProps> = ({ Component, pageProps }) => {
 
               body,
               html {
-                background-color: ${theme.colors.background};
+                background-color: ${colors.background};
               }
             `}
           />
-          <Component {...pageProps} key={pageKey} />
+          <SSRProvider>
+            <Component {...pageProps} key={pageKey} />
+          </SSRProvider>
         </ThemeProvider>
       </AnimatePresence>
     </AnimateSharedLayout>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,3 @@
-import { SSRProvider } from '@react-aria/ssr';
 import Document, {
   DocumentContext,
   DocumentInitialProps,
@@ -38,9 +37,7 @@ class CustomDocument extends Document {
           />
         </Head>
         <body>
-          <SSRProvider>
-            <Main />
-          </SSRProvider>
+          <Main />
           <NextScript />
           <style jsx global>
             {`

--- a/src/pages/approach.tsx
+++ b/src/pages/approach.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
 
 import { ApproachPage } from '~/components';
 

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,4 +1,5 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
+
 import { Layout } from '~/components';
 
 const BlogIndexPage: NextPage = () => {

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -1,4 +1,5 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
+
 import { Layout } from '~/components';
 
 const ContactIndexPage: NextPage = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
 
 import { HomePage } from '~/components';
 

--- a/src/pages/work/index.tsx
+++ b/src/pages/work/index.tsx
@@ -1,4 +1,5 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
+
 import { Layout } from '~/components';
 
 const WorkIndexPage: NextPage = () => {

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,4 @@
-export const palette = {
+const palette = {
   coral: '#f73a52',
   darkBlue: '#05001e',
   darkBlueAlt: '#0f0d34',
@@ -6,6 +6,7 @@ export const palette = {
   offWhite: '#ecf0f4',
   workThumbnailBg: '#30308a',
 };
+
 export const colors = {
   ...palette,
   action: palette.coral,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,8 +3,8 @@ import { spacing } from './spacing';
 import { linkVariants, textVariants } from './typography';
 
 export * from './breakpoints';
+export * from './colors';
 export * from './spacing';
-export type { ThemeColor } from './colors';
 export type { ThemeLinkVariants, ThemeTextVariants } from './typography';
 export * from './util';
 


### PR DESCRIPTION
- Add eslint-plugin-import to enforce rules about import statements
- Resolve all oustanding eslint errors/warnings
- Use "import type" when only importing types
- Replace dangerous peer-index named imports with peer named imports

B2-94