### PR TITLE
update src path for cse study img

### DIFF
--- a/src/components/WorkPage/FeaturedCaseStudyHero.tsx
+++ b/src/components/WorkPage/FeaturedCaseStudyHero.tsx
@@ -81,7 +81,7 @@ export const FeaturedCaseStudyHero: FC = () => {
             }
           }
         `}
-        src="/home/featured-case-study-home-1.png"
+        src={require('../HomePage/featured-case-study-1.png')}
       />
       <TextContainer>
         <Heading


### PR DESCRIPTION
Update the src path for the Paint a Photo image on the Work page. 

I tried using the full image with the bottom navigation but the aspect ratio was getting lost. I tried using `object-fit` but it would just crop the image to fit inside the div, so I just ended up using the `featured-case-study-1.png` img from the `HomePage` component. I mocked it up in a codepen but wasn't able to get much farther. Open to suggestions!