### PR TITLE
added dark box shadow to contrast bright name text

### DIFF
--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -52,6 +52,15 @@ const ImageNoise = styled.div`
   z-index: 3;
 `;
 
+const ImageBoxShadow = styled.div`
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 3;
+  -webkit-box-shadow: inset 0px -80px 40px -30px #05001eab; 
+  box-shadow: inset 0px -80px 40px -30px #05001eab;
+`;
+
 const MemberInfo = styled.div`
   margin-top: -${spacing.md};
   padding-left: ${spacing.sm};
@@ -97,6 +106,7 @@ export const TeamMemberCard: FC<TeamMemberCardProps> = ({
     <article>
       <ImageFilter>
         <ImageNoise />
+        <ImageBoxShadow />
         <ResponsiveImage alt={name} src={src} />
       </ImageFilter>
       <MemberInfo>


### PR DESCRIPTION
Card issue link: [b2-125](https://b2io.atlassian.net/browse/B2-125)

The staff image names should now be easier to read. 
