### PR TITLE
b2-132 added text-shadow to pageHero comp

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,16 @@
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,
     "sort-keys": ["warn", "asc", { "caseSensitive": false, "natural": true }],
-    "sort-vars": "warn"
+    "sort-vars": "warn",
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"],
+        "allowSeparatedGroups": false
+      }
+    ]
   }
 }

--- a/src/components/ApproachPage/HowWeEngage.tsx
+++ b/src/components/ApproachPage/HowWeEngage.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { FC } from 'react';
 
 import { Heading, IconCard, Link } from '~/components';
-import { spacing, atMinTablet, atMinXL } from '~/theme';
+import { atMinTablet, atMinXL, spacing } from '~/theme';
 
 import { IconCardGrid } from '../IconCard';
 

--- a/src/components/ContactPage/ContactForm.tsx
+++ b/src/components/ContactPage/ContactForm.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { FC } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { Heading, Text } from '~/components';
 import theme, { atMinTablet, colors, cssClamp, spacing } from '~/theme';

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,10 +1,10 @@
 import styled, { StyledComponent } from '@emotion/styled';
 
 import {
+  atMinDesktop,
   atMinTablet,
   atMinXL,
   atMinXXL,
-  atMinDesktop,
   viewMaxWidth,
 } from '~/theme';
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { FC } from 'react';
 
-import { atMinTablet, atMinLg, colors, spacing } from '~/theme';
+import { atMinLg, atMinTablet, colors, spacing } from '~/theme';
 
 import { Container } from './Container';
 import { LogoIcon } from './icons';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 
-import { atMinTablet, atMinSm, atMinXXL, colors, spacing } from '~/theme';
+import { atMinSm, atMinTablet, atMinXXL, colors, spacing } from '~/theme';
 
 import { Container } from './Container';
 import { LogoWithName } from './icons';

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { FC } from 'react';
 
-import { atMinLg, atMinLargeDesktop, atMinXL, cssClamp } from '~/theme';
+import { atMinLg, atMinLargeDesktop, atMinXL, cssClamp, colors } from '~/theme';
 
 import { DynamicImage, DynamicImageProps } from './DynamicImage';
 import { Heading } from './Heading';
@@ -35,7 +35,8 @@ const Image = styled(DynamicImage)`
 const HeaderText = styled(Heading)`
   padding-top: ${cssClamp([11, 'smMobile'], [16, 'mobile'], [21.5, 'tablet'])};
   position: relative;
-
+  text-shadow: -0.25rem 0.25rem 0.375rem ${colors.darkBlue};
+  
   ${atMinLg} {
     max-width: 53rem;
   }

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { FC } from 'react';
 
-import { atMinLg, atMinLargeDesktop, atMinXL, cssClamp, colors } from '~/theme';
+import { atMinLargeDesktop, atMinLg, atMinXL, colors, cssClamp } from '~/theme';
 
 import { DynamicImage, DynamicImageProps } from './DynamicImage';
 import { Heading } from './Heading';


### PR DESCRIPTION
Card issue link: [b2-132](https://b2io.atlassian.net/browse/B2-132)

- Added a text-shadow style to the PageHero component
- All PageHero texts will now be easier to read when over an image.

Would you guys consider this best practice? Instead of adding the same style to 3 different pages, I just added the style once to the one shared component (PageHero).