### PR TITLE
Fixed mobile menu styling

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -43,11 +43,17 @@ const Nav = styled.nav`
   li {
     margin-bottom: ${spacing.xs};
   }
+
+  a {
+    font-size: 2.5rem;
+    font-weight: bold;
+    line-height: 1.1;
+  }
 `;
 
 const ContactLink = styled(Link)`
   display: table;
-  margin: ${spacing.lg} ${spacing.lg} 0;
+  margin: 3rem ${spacing.lg} 0;
 `;
 
 export const MobileMenu: FC = ({ ...props }) => {


### PR DESCRIPTION
Looks like the clamp in Global Styles had repercussions on the spacing for this menu nav. As this is a one-off situation, I just used a styled component fix to override the settings on `<a>` tags that kick in here on the mobile breakpoint.

Bug:
![Screen Shot 2021-08-31 at 11 19 34 AM](https://user-images.githubusercontent.com/13206464/131529972-23b8d41a-0271-42eb-9a0a-34ee663e0113.png)


Also noticed a spacing discrepancy between the `ContactLink`s

![Screen Shot 2021-08-31 at 11 17 47 AM](https://user-images.githubusercontent.com/13206464/131529631-106b2137-6242-47a3-a4cd-464043b34cd8.png)
