### PR TITLE
B2 30 case study nav component

### DIFF
--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -4,7 +4,6 @@ import type { FC } from 'react';
 import { Layout } from '~/components';
 import { atMinTablet, atMinXL, cssClamp, spacing } from '~/theme';
 
-import { CaseStudy, CaseStudyNav } from '../WorkPage/CaseStudyNav';
 import { BuiltForResults } from './BuiltForResults';
 import { DesignedForHumans } from './DesignedForHumans';
 import { FeaturedCaseStudy } from './FeaturedCaseStudy';
@@ -55,22 +54,6 @@ export const HomePage: FC<HomePageProps> = () => {
           }
         `}
       />
-      <CaseStudyNav>
-        <CaseStudy
-          alt="netjets case study image"
-          client="NetJets"
-          caseStudy="Fly NetJets"
-          href="/work/netjets"
-          src={require('../WorkPage/images/netjets.jpg')}
-        />
-        <CaseStudy
-          alt="scopebuilder case study image"
-          caseStudy="ScopeBuilder"
-          client="AEP"
-          href="/work/scopebuilder"
-          src={require('../WorkPage/images/scopebuilder.jpg')}
-        />
-      </CaseStudyNav>
     </Layout>
   );
 };

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import { Layout } from '~/components';
 import { atMinTablet, atMinXL, cssClamp, spacing } from '~/theme';
 
+import { CaseStudy, CaseStudyNav } from '../WorkPage/CaseStudyNav';
 import { BuiltForResults } from './BuiltForResults';
 import { DesignedForHumans } from './DesignedForHumans';
 import { FeaturedCaseStudy } from './FeaturedCaseStudy';
@@ -54,6 +55,22 @@ export const HomePage: FC<HomePageProps> = () => {
           }
         `}
       />
+      <CaseStudyNav>
+        <CaseStudy
+          alt="netjets case study image"
+          client="NetJets"
+          caseStudy="Fly NetJets"
+          href="/work/netjets"
+          src={require('../WorkPage/images/netjets.jpg')}
+        />
+        <CaseStudy
+          alt="scopebuilder case study image"
+          caseStudy="ScopeBuilder"
+          client="AEP"
+          href="/work/scopebuilder"
+          src={require('../WorkPage/images/scopebuilder.jpg')}
+        />
+      </CaseStudyNav>
     </Layout>
   );
 };

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -1,4 +1,5 @@
 import css from '@emotion/css';
+import styled from '@emotion/styled';
 import NextImage, { ImageProps as NextImageProps } from 'next/image';
 import { Children, cloneElement, FC, ReactElement } from 'react';
 
@@ -13,6 +14,52 @@ export type CaseStudyProps = NextImageProps & {
   src: Exclude<NextImageProps['src'], string | StaticImageData>;
 };
 
+export const CaseStudyNavContainer = styled.section`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  margin-top: ${spacing.xxl2};
+  object-fit: contain;
+
+  ${atMinXL} {
+    flex-direction: row;
+    gap: 2rem;
+    justify-content: center;
+    margin-bottom: ${spacing.xxl3};
+  }
+`;
+
+export const CaseStudyContainer = styled.div`
+  margin-bottom: 4.5rem;
+  position: relative;
+  width: ${cssClamp([13.5, 'mobile'], [29.125, 'desktop'])};
+
+  &:nth-of-type(2) article {
+    right: unset;
+    ${atMinXL} {
+      right: -3rem;
+      text-align: right;
+    }
+  }
+  ${atMinXL} {
+    margin-bottom: 0;
+  }
+`;
+
+export const CaseStudyInfo = styled.article`
+  left: 0;
+  margin-top: 1rem;
+  position: unset;
+  z-index: 2;
+  ${atMinXL} {
+    left: -6rem;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
+
 export const CaseStudy: FC<CaseStudyProps> = ({
   client,
   href,
@@ -21,24 +68,7 @@ export const CaseStudy: FC<CaseStudyProps> = ({
   src,
 }) => {
   return (
-    <div
-      css={css`
-        margin-bottom: 4.5rem;
-        position: relative;
-        width: ${cssClamp([13.5, 'mobile'], [29.125, 'desktop'])};
-
-        &:nth-of-type(2) article {
-          right: unset;
-          ${atMinXL} {
-            right: -3rem;
-            text-align: right;
-          }
-        }
-        ${atMinXL} {
-          margin-bottom: 0;
-        }
-      `}
-    >
+    <CaseStudyContainer>
       <NextImage
         alt={alt}
         css={css`
@@ -46,20 +76,7 @@ export const CaseStudy: FC<CaseStudyProps> = ({
         `}
         src={src}
       />
-      <article
-        css={css`
-          left: 0;
-          margin-top: 1rem;
-          position: unset;
-          z-index: 2;
-          ${atMinXL} {
-            left: -6rem;
-            position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
-          }
-        `}
-      >
+      <CaseStudyInfo>
         <Text as="span">{client}</Text>
         <Heading
           as="h2"
@@ -78,34 +95,17 @@ export const CaseStudy: FC<CaseStudyProps> = ({
         <Link href={href} variant="CTA">
           Explore case study
         </Link>
-      </article>
-    </div>
+      </CaseStudyInfo>
+    </CaseStudyContainer>
   );
 };
 
 export const CaseStudyNav: FC = ({ children, ...props }) => {
   return (
-    <section
-      css={css`
-        align-items: center;
-        display: flex;
-        flex-direction: column;
-
-        margin-top: ${spacing.xxl2};
-        object-fit: contain;
-
-        ${atMinXL} {
-          flex-direction: row;
-          gap: 2rem;
-          justify-content: center;
-          margin-bottom: ${spacing.xxl3};
-        }
-      `}
-      {...props}
-    >
+    <CaseStudyNavContainer {...props}>
       {Children.map(children, (child) =>
         cloneElement(child as ReactElement<any>, { as: 'div' }),
       )}
-    </section>
+    </CaseStudyNavContainer>
   );
 };

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -1,33 +1,111 @@
 import css from '@emotion/css';
-import { Children, cloneElement, ElementType, FC, ReactElement } from 'react';
+import NextImage, { ImageProps as NextImageProps } from 'next/image';
+import { Children, cloneElement, FC, ReactElement } from 'react';
 
 import { Heading, Link, Text } from '~/components';
+import { atMinXL, cssClamp, spacing } from '~/theme';
 
-export type CaseStudyProps = {
+export type CaseStudyProps = NextImageProps & {
+  alt: string;
+  caseStudy: string;
   client: string;
   href: string;
-  imgSrc: string;
-  caseStudyLink: string;
-  caseStudyName: string;
+  src: Exclude<NextImageProps['src'], string | StaticImageData>;
 };
 
 export const CaseStudy: FC<CaseStudyProps> = ({
   client,
   href,
-  caseStudyLink,
-  caseStudyName,
+  caseStudy,
+  alt,
+  src,
 }) => {
   return (
-    <article
+    <div
       css={css`
-        background: gray;
+        margin-bottom: 4.5rem;
+        position: relative;
+        width: ${cssClamp([13.5, 'mobile'], [29.125, 'desktop'])};
+
+        &:nth-of-type(2) article {
+          right: unset;
+          ${atMinXL} {
+            right: -3rem;
+            text-align: right;
+          }
+        }
+        ${atMinXL} {
+          margin-bottom: 0;
+        }
       `}
     >
-      <Text as="span">{client}</Text>
-      <Heading>{caseStudyName}</Heading>
-      <Link href={href} variant="CTA">
-        {caseStudyLink}
-      </Link>
-    </article>
+      <NextImage
+        alt={alt}
+        css={css`
+          opacity: 0.3;
+        `}
+        src={src}
+      />
+      <article
+        css={css`
+          left: 0;
+          margin-top: 1rem;
+          position: unset;
+          z-index: 2;
+          ${atMinXL} {
+            left: -6rem;
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+          }
+        `}
+      >
+        <Text as="span">{client}</Text>
+        <Heading
+          as="h2"
+          color="coral"
+          css={css`
+            font-size: 1.875rem;
+            line-height: 1.25;
+            ${atMinXL} {
+              font-size: 3.125rem;
+            }
+          `}
+          variant="h2"
+        >
+          {caseStudy}
+        </Heading>
+        <Link href={href} variant="CTA">
+          Explore case study
+        </Link>
+      </article>
+    </div>
+  );
+};
+
+export const CaseStudyNav: FC = ({ children, ...props }) => {
+  return (
+    <section
+      css={css`
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+
+        margin-top: ${spacing.xxl2};
+        object-fit: contain;
+
+        ${atMinXL} {
+          flex-direction: row;
+          gap: 2rem;
+          justify-content: center;
+          margin-bottom: ${spacing.xxl3};
+        }
+      `}
+      {...props}
+    >
+      {Children.map(children, (child) =>
+        cloneElement(child as ReactElement<any>, { as: 'div' }),
+      )}
+    </section>
   );
 };

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -48,16 +48,29 @@ export const CaseStudyContainer = styled.div`
 `;
 
 export const CaseStudyInfo = styled.article`
-  left: 0;
-  margin-top: 1rem;
-  position: unset;
+  margin-left: 2rem;
+  margin-top: -3rem;
+  position: relative;
   z-index: 2;
   ${atMinXL} {
     left: -6rem;
+    margin-top: 0;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
   }
+`;
+
+export const OverlayWrapper = styled.div`
+  position: relative;
+`;
+
+export const Overlay = styled.div`
+  background: rgba(35, 35, 100, 0.8);
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
 `;
 
 export const CaseStudy: FC<CaseStudyProps> = ({
@@ -69,13 +82,18 @@ export const CaseStudy: FC<CaseStudyProps> = ({
 }) => {
   return (
     <CaseStudyContainer>
-      <NextImage
-        alt={alt}
-        css={css`
-          opacity: 0.3;
-        `}
-        src={src}
-      />
+      <OverlayWrapper>
+        <Overlay />
+        <NextImage
+          alt={alt}
+          css={css`
+            div {
+              position: absolute;
+            }
+          `}
+          src={src}
+        />
+      </OverlayWrapper>
       <CaseStudyInfo>
         <Text as="span">{client}</Text>
         <Heading

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -4,7 +4,7 @@ import NextImage, { ImageProps as NextImageProps } from 'next/image';
 import { Children, cloneElement, FC, ReactElement } from 'react';
 
 import { Heading, Link, Text } from '~/components';
-import { atMinXL, cssClamp, spacing } from '~/theme';
+import { atMinXL, colors, cssClamp, spacing } from '~/theme';
 
 export type CaseStudyProps = NextImageProps & {
   alt: string;
@@ -69,8 +69,9 @@ export const OverlayWrapper = styled.div`
 `;
 
 export const Overlay = styled.div`
-  background: rgba(35, 35, 100, 0.8);
+  background: ${colors.midBlue};
   height: 100%;
+  mix-blend-mode: hard-light;
   position: absolute;
   width: 100%;
   z-index: 1;
@@ -90,7 +91,7 @@ export const CaseStudy: FC<CaseStudyProps> = ({
         <NextImage
           alt={alt}
           css={css`
-            position: absolute;
+            position: relative;
           `}
           src={src}
         />

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -31,7 +31,7 @@ export const CaseStudyNavContainer = styled.section`
 `;
 
 export const CaseStudyContainer = styled.div`
-  margin-bottom: 4.5rem;
+  margin-bottom: 9rem;
   position: relative;
   width: ${cssClamp([13.5, 'mobile'], [29.125, 'desktop'])};
 
@@ -48,12 +48,15 @@ export const CaseStudyContainer = styled.div`
 `;
 
 export const CaseStudyInfo = styled.article`
-  margin-left: 2rem;
+  left: 50%;
+  /* margin-left: 2rem; */
   margin-top: -3rem;
-  position: relative;
+  position: absolute;
+  transform: translateX(-50%);
   z-index: 2;
   ${atMinXL} {
     left: -6rem;
+    margin-left: 0;
     margin-top: 0;
     position: absolute;
     top: 50%;
@@ -87,9 +90,7 @@ export const CaseStudy: FC<CaseStudyProps> = ({
         <NextImage
           alt={alt}
           css={css`
-            div {
-              position: absolute;
-            }
+            position: absolute;
           `}
           src={src}
         />
@@ -110,7 +111,13 @@ export const CaseStudy: FC<CaseStudyProps> = ({
         >
           {caseStudy}
         </Heading>
-        <Link href={href} variant="CTA">
+        <Link
+          css={css`
+            width: max-content;
+          `}
+          href={href}
+          variant="CTA"
+        >
           Explore case study
         </Link>
       </CaseStudyInfo>

--- a/src/components/WorkPage/CaseStudyNav.tsx
+++ b/src/components/WorkPage/CaseStudyNav.tsx
@@ -1,0 +1,33 @@
+import css from '@emotion/css';
+import { Children, cloneElement, ElementType, FC, ReactElement } from 'react';
+
+import { Heading, Link, Text } from '~/components';
+
+export type CaseStudyProps = {
+  client: string;
+  href: string;
+  imgSrc: string;
+  caseStudyLink: string;
+  caseStudyName: string;
+};
+
+export const CaseStudy: FC<CaseStudyProps> = ({
+  client,
+  href,
+  caseStudyLink,
+  caseStudyName,
+}) => {
+  return (
+    <article
+      css={css`
+        background: gray;
+      `}
+    >
+      <Text as="span">{client}</Text>
+      <Heading>{caseStudyName}</Heading>
+      <Link href={href} variant="CTA">
+        {caseStudyLink}
+      </Link>
+    </article>
+  );
+};


### PR DESCRIPTION
Zeplin comp for reference:
<img width="1216" alt="Screen Shot 2021-09-14 at 11 16 14 AM" src="https://user-images.githubusercontent.com/19558580/133285149-1b79cde6-1acb-4202-983c-499b186bb7b0.png">

📌 `CaseStudyNav` component is at the bottom of the homepage. I will remove once PR is approved!

Looking for feedback on this component since I feel like I over-engineered some things to get it looking like the designs 😬

📓 **A couple of notes:**
For the image overlay -- I had a little trouble getting it to work on both desktop and mobile so I just adjusted the image opacity which I think works better for readability, but open to feedback on recreating this!

On mobile, I positioned the text directly below the image since I had a bit of trouble getting this to work, but I do think it's better for readability. 
