### PR TITLE
Cleaned up some console errors.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
     }
   },
   "rules": {
+    "@next/next/no-document-import-in-page": "off",
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/explicit-member-accessibility": 0,
     "@typescript-eslint/indent": 0,

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,6 @@ const config = {
               "img-src 'self' data:;",
               "manifest-src 'self';",
               "object-src 'none';",
-              "prefetch-src 'self';",
               "script-src 'self';",
               "style-src 'self' 'unsafe-inline';",
             ].join(' '),

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -92,7 +92,6 @@ const CustomApp: FC<AppProps> = ({ Component, pageProps }) => {
           as="font"
           crossOrigin="anonymous"
           href="/RoobertItalicGX.woff2"
-          rel="preload"
         />
         <link rel="manifest" href="/site.webmanifest"></link>
         <meta charSet="utf-8" />


### PR DESCRIPTION
This PR tackles cards:
https://github.com/b2io/base2.io/issues/690
https://github.com/b2io/base2.io/issues/721

🩹  workaround for old nextjs es lint bug,
https://github.com/vercel/next.js/issues/28971
Bug found in old version of next / eslint dependecies, disabling the rule is a temporary workaround. Blocked from building the app without the rule off. True fix is by updating dependencies which is its own task/pr/card. 

➖  deprecated prefetch src csp,
![image](https://github.com/b2io/base2.io/assets/32186552/131ce01e-1ef7-4ff6-8f9c-1e21b3f41628)
The Prefetch src CSP rule is deprecated and unrecognized by chromium/Firefox. Safe to delete.

🩹  workaround preload attribute on italic font link
App struggled to preload an italic font link. Workaround was to remove the preload attribute. No discernible performance impact without the preload.


* Note: If viewing the vercel live preview, there will be a script-src-elm csp console error but that is only specific to the preview. To get a more accurate reading, you would have to `npm run build` and `npm run start `the app locally. 

Console should be squeaky clean! 👍 
...for now 👀 