### PR TITLE
822: CardGrid accessibility issue

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -192,9 +192,9 @@ export type BasicCardProps = {
   text: string;
 };
 
-export const BasicCard: FC<BasicCardProps> = ({ heading, text }) => {
+export const BasicCard: FC<BasicCardProps> = ({ heading, text, ...props }) => {
   return (
-    <Card>
+    <Card {...props}>
       <Heading as="h2" variant="h2">
         {heading}
       </Heading>


### PR DESCRIPTION
- passed props to BasicCard in order to give children access to "as" prop and properly render as "li" elements

Before
![Screenshot 2024-01-23 at 9 50 41 AM](https://github.com/b2io/base2.io/assets/17680907/a0039079-2a50-47e1-99e1-4335b8036b87)


After
![Screenshot 2024-01-23 at 1 38 54 PM](https://github.com/b2io/base2.io/assets/17680907/1dc0361e-71a8-4725-8f17-499daac55a8f)
