### PR TITLE
824: ResultCard accessibility issue

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -61,7 +61,11 @@ export type ResultCardProps = {
   text: string;
 };
 
-export const ResultCard: FC<ResultCardProps> = ({ heading, text }) => {
+export const ResultCard: FC<ResultCardProps> = ({
+  heading,
+  text,
+  ...props
+}) => {
   const [highlight, ...remainder] = heading.split(' ');
   return (
     <Card
@@ -74,6 +78,7 @@ export const ResultCard: FC<ResultCardProps> = ({ heading, text }) => {
           width: 2.5rem;
         }
       `}
+      {...props}
     >
       <Heading
         as="h3"


### PR DESCRIPTION
passed props to ResultCard in order to give children access to "as" prop and properly render as "li" elements

Before
![Screenshot 2024-01-23 at 3 54 45 PM](https://github.com/b2io/base2.io/assets/17680907/246933e7-405e-47c8-8e90-042ec1a2e014)

After
![Screenshot 2024-01-23 at 3 58 07 PM](https://github.com/b2io/base2.io/assets/17680907/572b636a-2509-4b0e-b2ff-7685f7ba074e)
