### PR TITLE
826:  fix ResultCard typography 

### DIFF
--- a/src/components/Common/Card.tsx
+++ b/src/components/Common/Card.tsx
@@ -16,7 +16,7 @@ import {
   List,
   Text,
 } from '~/components';
-import { atMaxSm, atMinTablet, colors, spacing } from '~/theme';
+import { atMinTablet, colors, spacing } from '~/theme';
 
 export const CardHeading: FC<PropsWithChildren> = ({ children, ...props }) => {
   return <div {...props}>{children}</div>;
@@ -70,49 +70,25 @@ export const ResultCard: FC<ResultCardProps> = ({
   return (
     <Card
       css={css`
+        gap: 0;
         &::before {
           background: ${colors.lightBlue};
           content: ' ';
           display: block;
           height: 0.25rem;
+          margin-bottom: ${spacing.sm};
           width: 2.5rem;
         }
       `}
       {...props}
     >
-      <Heading
-        as="h3"
-        color="coral"
-        variant="h1"
-        css={css`
-          ${atMaxSm} {
-            font-size: 3.5rem;
-          }
-        `}
-      >
+      <Heading as="h3" color="coral" variant="h2">
         {highlight}
-        <br />
-        <Text
-          as="span"
-          css={css`
-            display: block;
-          `}
-          variant="h2"
-        >
-          {remainder.join(' ')}
-        </Text>
       </Heading>
-      <Text
-        as="p"
-        css={css`
-          margin: 0;
-          ${atMaxSm} {
-            max-width: 21.875rem;
-          }
-        `}
-      >
-        {text}
-      </Text>
+      <Heading as="h4" variant="h3">
+        {remainder.join(' ')}
+      </Heading>
+      <Text>{text}</Text>
     </Card>
   );
 };


### PR DESCRIPTION
- refactored ResultCard to reduce inline typography styling and prevent breakage

**Note**
The goal with this is not to make the styling match the designs but to prevent broken layouts and simplify the approach to typography until it can be addressed 

Resolves [826](https://github.com/orgs/b2io/projects/15/views/1?pane=issue&itemId=51183468)