### PR TITLE
855: Header gradient not being applied

### DIFF
--- a/src/components/Layouts/Header.tsx
+++ b/src/components/Layouts/Header.tsx
@@ -16,8 +16,8 @@ import { XmasMarquee } from '../XmasMarquee';
 const Root = styled.header`
   background-image: linear-gradient(
     to bottom,
-    rgba(4 0 28 0.84) 35%,
-    rgba(6 2 27 0)
+    rgba(4, 0, 28, 0.84) 35%,
+    rgba(6, 2, 27, 0)
   );
   height: 6.188rem;
   left: 0;


### PR DESCRIPTION
- adjusted syntax and rule is now applied

**Test**
- run site locally or visit preview
- inspect Header 
- verify that "background-image" rule is valid and visually applied

Resolves [855](https://github.com/orgs/b2io/projects/15/views/1?pane=issue&itemId=52557642)