### PR TITLE
857: update sizing of quotation text

### DIFF
--- a/src/components/Common/QuotedImage.tsx
+++ b/src/components/Common/QuotedImage.tsx
@@ -34,14 +34,14 @@ const TextContainer = styled.div`
   }
 
   ${atMinTablet} {
-    max-width: 75vw;
+    max-width: 40rem;
     padding-top: 4.5rem;
   }
 
   ${atMinXL} {
     display: flex;
     margin-left: -3.5rem;
-    max-width: 85rem;
+    max-width: 60rem;
     padding-top: 6rem;
   }
 
@@ -101,7 +101,7 @@ export const QuotedImage: FC<QuotedImageProps> = ({
         <div>
           <Heading
             as="h2"
-            variant="quotationText"
+            variant="h2"
             css={css`
               margin-bottom: ${spacing.md};
 

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -161,19 +161,6 @@ export const textVariants = {
     margin: '0 0 0 -.5rem',
     padding: 0,
   },
-  quotationText: {
-    [atMinTablet]: {
-      fontVariationSettings: '"wght" 900',
-      lineHeight: 1.125,
-    },
-    color: colors.text,
-    fontSize: cssClamp([2.5, 'mobile'], [6.25, 'tablet']),
-    fontVariationSettings: '"wght" 750',
-    letterSpacing: 'normal',
-    lineHeight: 1.1,
-    margin: 0,
-    padding: 0,
-  },
   serviceTitle: {
     [atMinTablet]: {
       lineHeight: 1.33,


### PR DESCRIPTION
- utilized existing h3 variant for quotation text
- adjusted styling
- removed quotationText variant


Before 

![Screenshot 2024-02-07 at 2 38 06 PM](https://github.com/b2io/base2.io/assets/17680907/7e7cba4c-dbd3-466a-bef5-434d6b580c53)

After 

![Screenshot 2024-02-07 at 2 38 35 PM](https://github.com/b2io/base2.io/assets/17680907/2b771a8c-636d-42ed-ab3c-d4be37ef018a)


Resolves [857](https://github.com/orgs/b2io/projects/15/views/1?pane=issue&itemId=52565420)